### PR TITLE
fix: prevent R2 EntityTooSmall error on multi-image uploads

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -60,7 +60,6 @@ export function HomePage() {
           timeLimit,
           downloadLimit,
           onProgress: (progress) => {
-            setZippingProgress(null); // Clear zipping when upload starts
             setUploadProgress(progress);
           },
           onZipProgress: (percent) => {
@@ -114,6 +113,7 @@ export function HomePage() {
     } finally {
       setUploading(false);
       setUploadProgress(null);
+      setZippingProgress(null);
       setCanceller(null);
       setKeychain(null);
     }

--- a/shared/config.ts
+++ b/shared/config.ts
@@ -14,6 +14,7 @@ export const UPLOAD_LIMITS = {
   MULTIPART_THRESHOLD: 100 * BYTES.MB, // Use multipart for files > 100MB
   DEFAULT_PART_SIZE: 200 * BYTES.MB, // 200MB per part (increased for 1TB support)
   MAX_PART_SIZE: 5 * BYTES.GB, // 5GB per part (R2/S3 limit)
+  MIN_PART_SIZE: 5 * BYTES.MB, // 5MB minimum part size (R2/S3 requirement)
   MAX_PARTS: 10000, // Cloudflare R2 limit
   MAX_FILES_PER_ARCHIVE: 64,
 } as const;


### PR DESCRIPTION
## Summary
- **Backend**: Guard against small last parts in `calculateOptimalPartSize` — when the remainder would be < 5MB, reduce part count and redistribute evenly to prevent R2 `EntityTooSmall` rejection
- **Frontend**: Add one-part delay buffer in `uploadMultipartStream` to merge small final parts into the previous part, and fall back to single-part `PutObject` upload when the streaming zip produces far less data than estimated (e.g. `client-zip` early close)
- **Frontend**: Fix streaming zip progress UI — move `setZippingProgress(null)` from the per-tick `onProgress` callback to the `finally` block so "Compressing files..." doesn't flicker during concurrent zip + upload
- **Shared**: Add `MIN_PART_SIZE` (5MB) constant to `UPLOAD_LIMITS`

## Test plan
- [ ] Upload 55 images totaling ~610MB with encryption off — should succeed (streaming zip path, with fallback if stream closes early)
- [ ] Upload files where compressed size lands just above a multiple of 200MB — verify no EntityTooSmall error
- [ ] Upload > 500MB of files — verify "Compressing files..." progress shows smoothly without flickering
- [ ] Check browser console for merge or fallback log messages

closes ENG-1830