### PR TITLE
feat: resilient uploads on slow connections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,15 @@ docker-compose up
 3. Redis stores metadata (TTL, download limits, encryption flags)
 4. Download URLs contain encryption key in hash fragment for client-side decryption
 
+**Resilient Uploads**:
+- **Upload resumability**: Multipart upload state (uploadId, completed parts, encryption counter) is persisted to IndexedDB via `frontend/src/lib/upload-state.ts`. On page reload, the user is prompted to resume incomplete uploads, skipping already-uploaded parts.
+- **Preflight speed test**: Before multipart uploads (>100MB), a speed test uploads 5x100MB parts concurrently to S3 via pre-signed URLs to measure real throughput, then cleans up the test objects.
+- **Adaptive part sizing**: Upload part size is selected from `PART_SIZE_TIERS` (defined in `shared/config.ts`) based on the measured upload speed from the preflight test.
+- **Stall detection**: Instead of hard XHR timeouts, uploads use progress-based stall detection — if no bytes are transferred for a threshold period, the part is retried. Retries pause automatically when the browser goes offline.
+- **Connection quality UI**: The upload progress component displays real-time connection quality states (e.g., "Checking speed...", online/offline awareness) and updates every second during uploads.
+
 **Key Backend Components**:
-- `backend/src/routes/upload.ts` - Pre-signed URL generation, multipart orchestration
+- `backend/src/routes/upload.ts` - Pre-signed URL generation, multipart orchestration, resume endpoint, speed test endpoints
 - `backend/src/routes/download.ts` - URL signing, download count enforcement
 - `backend/src/storage/s3.ts` - S3 client with multipart support
 - `backend/src/storage/redis.ts` - Metadata operations with TTL
@@ -51,7 +58,8 @@ docker-compose up
 
 **Key Frontend Components**:
 - `frontend/src/lib/crypto.ts` - AES-GCM encryption, HKDF key derivation
-- `frontend/src/lib/api.ts` - Direct S3 multipart uploads, download logic
+- `frontend/src/lib/api.ts` - Direct S3 multipart uploads, download logic, stall detection, adaptive part sizing
+- `frontend/src/lib/upload-state.ts` - IndexedDB persistence for multipart upload resumability
 - `frontend/src/stores/app.ts` - Zustand store (config, upload state, files)
 - `frontend/src/pages/Home.tsx` - Upload interface
 - `frontend/src/pages/Download.tsx` - Download/decryption interface
@@ -73,4 +81,7 @@ See `.env.example` for full list of configurable limits and UI options.
 - `GET /config` - Client configuration (limits, defaults)
 - `POST /upload/url` - Request pre-signed upload URL
 - `POST /upload/multipart/:id` - Initiate multipart upload
+- `POST /upload/multipart/:id/resume` - List completed parts for upload resumption
+- `POST /upload/speedtest` - Generate pre-signed URLs for preflight speed test parts
+- `POST /upload/speedtest/cleanup` - Clean up speed test objects from S3
 - `GET /download/url/:id` - Get pre-signed download URL

--- a/backend/src/routes/upload.ts
+++ b/backend/src/routes/upload.ts
@@ -282,6 +282,7 @@ export const uploadRoutes = new Elysia()
                 await storage.setField(id, 'uploadId', uploadId);
                 await storage.setField(id, 'multipart', 'true');
                 await storage.setField(id, 'numParts', numParts.toString());
+                await storage.setField(id, 'partSize', partSize.toString());
 
                 const response = {
                     useSignedUrl: true,
@@ -611,6 +612,84 @@ export const uploadRoutes = new Elysia()
         {
             body: t.Object({
                 uploadId: t.String(),
+            }),
+        },
+    )
+
+    // Resume multipart upload — generate pre-signed URLs for remaining parts
+    .post(
+        '/upload/multipart/:id/resume',
+        async ({ params, body }) => {
+            const { id } = params;
+            const { uploadId, completedPartNumbers } = body;
+            const requestId = randomBytes(4).toString('hex');
+
+            logger.info(
+                { requestId, id, uploadId, completedCount: completedPartNumbers.length },
+                'Resume upload request received',
+            );
+
+            // Verify upload exists in Redis
+            const fileInfo = await storage.getMetadata(id);
+            if (!fileInfo) {
+                logger.warn({ requestId, id }, 'File not found for resume');
+                return new Response(JSON.stringify({ error: 'Upload not found or expired' }), {
+                    status: 404,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+
+            if (!fileInfo.uploadId || fileInfo.uploadId !== uploadId) {
+                logger.warn({ requestId, id }, 'Upload ID mismatch');
+                return new Response(JSON.stringify({ error: 'Upload ID mismatch' }), {
+                    status: 400,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+
+            const numParts = fileInfo.numParts || 0;
+            const partSize = Number(fileInfo.partSize || DEFAULT_PART_SIZE);
+            const completedSet = new Set(completedPartNumbers);
+
+            // Generate pre-signed URLs for parts NOT in completedPartNumbers
+            const parts: PartInfo[] = [];
+            const BATCH_SIZE = 100;
+
+            for (let batchStart = 1; batchStart <= numParts; batchStart += BATCH_SIZE) {
+                const batchEnd = Math.min(batchStart + BATCH_SIZE - 1, numParts);
+                const batchPromises: Promise<PartInfo | null>[] = [];
+
+                for (let i = batchStart; i <= batchEnd; i++) {
+                    if (completedSet.has(i)) {
+                        continue;
+                    }
+                    batchPromises.push(
+                        storage
+                            .getSignedMultipartUploadUrl(id, uploadId, i, URL_EXPIRATION_SECONDS)
+                            .then((url) => ({
+                                partNumber: i,
+                                url,
+                                minSize: i === numParts ? 0 : partSize,
+                                maxSize: partSize,
+                            })),
+                    );
+                }
+
+                const batchParts = await Promise.all(batchPromises);
+                parts.push(...(batchParts.filter(Boolean) as PartInfo[]));
+            }
+
+            logger.info(
+                { requestId, id, remainingParts: parts.length, totalParts: numParts },
+                'Resume URLs generated',
+            );
+
+            return { parts, partSize, numParts };
+        },
+        {
+            body: t.Object({
+                uploadId: t.String(),
+                completedPartNumbers: t.Array(t.Number()),
             }),
         },
     );

--- a/backend/src/routes/upload.ts
+++ b/backend/src/routes/upload.ts
@@ -694,41 +694,34 @@ export const uploadRoutes = new Elysia()
         },
     )
 
-    // Speed test endpoint — accepts and discards a blob for preflight measurement
+    // Speed test — returns a pre-signed S3 URL for the client to upload to directly.
+    // The client uploads a junk blob to S3, measures speed, then we delete the object.
+    .post('/upload/speedtest', async () => {
+        const testId = `__speedtest__${randomBytes(8).toString('hex')}`;
+        const url = await storage.getSignedUploadUrl(testId, 60);
+        if (!url) {
+            return { error: 'Failed to generate speed test URL' };
+        }
+        logger.info({ testId }, 'Speed test URL generated');
+        return { url, testId };
+    })
+
+    // Clean up speed test object after the test completes
     .post(
-        '/upload/speedtest',
-        async ({ request }) => {
-            const startTime = Date.now();
-            let totalBytes = 0;
-
-            const body = request.body;
-            if (body) {
-                const reader = (body as ReadableStream).getReader();
-                // biome-ignore lint/correctness/noConstantCondition: intentional drain loop
-                while (true) {
-                    const { done, value } = await reader.read();
-                    if (done) {
-                        break;
-                    }
-                    if (value) {
-                        totalBytes += value.length;
-                    }
-                }
+        '/upload/speedtest/cleanup',
+        async ({ body }) => {
+            const { testId } = body;
+            try {
+                await storage.del(testId);
+                logger.info({ testId }, 'Speed test object deleted');
+            } catch (e) {
+                logger.warn({ testId, error: e }, 'Failed to delete speed test object');
             }
-
-            const elapsed = (Date.now() - startTime) / 1000;
-            const speedMbps =
-                elapsed > 0 ? Math.round((totalBytes / (1024 * 1024) / elapsed) * 10) / 10 : 0;
-            logger.info(
-                { totalBytes, elapsedMs: Date.now() - startTime, speedMbps },
-                'Speed test completed',
-            );
-
-            return { ok: true, speedMbps };
+            return { ok: true };
         },
         {
-            // Skip Elysia body parsing — we stream the raw body ourselves
-            // biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op parser
-            parse: () => {},
+            body: t.Object({
+                testId: t.String(),
+            }),
         },
     );

--- a/backend/src/routes/upload.ts
+++ b/backend/src/routes/upload.ts
@@ -696,17 +696,31 @@ export const uploadRoutes = new Elysia()
 
     // Speed test endpoint — accepts and discards a blob for preflight measurement
     .put('/upload/speedtest', async ({ request }) => {
-        // Consume and discard the body
+        const startTime = Date.now();
+        let totalBytes = 0;
+
         const body = request.body;
         if (body) {
             const reader = (body as ReadableStream).getReader();
             // biome-ignore lint/correctness/noConstantCondition: intentional drain loop
             while (true) {
-                const { done } = await reader.read();
+                const { done, value } = await reader.read();
                 if (done) {
                     break;
                 }
+                if (value) {
+                    totalBytes += value.length;
+                }
             }
         }
-        return { ok: true };
+
+        const elapsed = (Date.now() - startTime) / 1000;
+        const speedMbps =
+            elapsed > 0 ? Math.round((totalBytes / (1024 * 1024) / elapsed) * 10) / 10 : 0;
+        logger.info(
+            { totalBytes, elapsedMs: Date.now() - startTime, speedMbps },
+            'Speed test completed',
+        );
+
+        return { ok: true, speedMbps };
     });

--- a/backend/src/routes/upload.ts
+++ b/backend/src/routes/upload.ts
@@ -694,34 +694,57 @@ export const uploadRoutes = new Elysia()
         },
     )
 
-    // Speed test — returns a pre-signed S3 URL for the client to upload to directly.
-    // The client uploads a junk blob to S3, measures speed, then we delete the object.
+    // Speed test — creates a multipart upload with 5 pre-signed part URLs.
+    // The client uploads 5x100MB parts concurrently to measure real throughput.
     .post('/upload/speedtest', async () => {
+        const SPEEDTEST_NUM_PARTS = 5;
         const testId = `__speedtest__${randomBytes(8).toString('hex')}`;
-        const url = await storage.getSignedUploadUrl(testId, 60);
-        if (!url) {
-            return { error: 'Failed to generate speed test URL' };
+
+        try {
+            const uploadId = await storage.createMultipartUpload(testId);
+            if (!uploadId) {
+                return { error: 'Failed to create speed test upload' };
+            }
+
+            const parts = await Promise.all(
+                Array.from({ length: SPEEDTEST_NUM_PARTS }, (_, i) =>
+                    storage
+                        .getSignedMultipartUploadUrl(testId, uploadId, i + 1, 60)
+                        .then((url) => ({ partNumber: i + 1, url })),
+                ),
+            );
+
+            logger.info(
+                { testId, uploadId, numParts: SPEEDTEST_NUM_PARTS },
+                'Speed test URLs generated',
+            );
+            return { testId, uploadId, parts };
+        } catch (e) {
+            logger.warn({ testId, error: e }, 'Speed test setup failed');
+            return { error: 'Speed test setup failed' };
         }
-        logger.info({ testId }, 'Speed test URL generated');
-        return { url, testId };
     })
 
     // Clean up speed test object after the test completes
     .post(
         '/upload/speedtest/cleanup',
         async ({ body }) => {
-            const { testId } = body;
+            const { testId, uploadId } = body;
             try {
-                await storage.del(testId);
-                logger.info({ testId }, 'Speed test object deleted');
+                // Abort the multipart upload (cleans up parts from S3)
+                if (uploadId) {
+                    await storage.abortMultipartUpload(testId, uploadId);
+                }
+                logger.info({ testId }, 'Speed test cleaned up');
             } catch (e) {
-                logger.warn({ testId, error: e }, 'Failed to delete speed test object');
+                logger.warn({ testId, error: e }, 'Failed to clean up speed test');
             }
             return { ok: true };
         },
         {
             body: t.Object({
                 testId: t.String(),
+                uploadId: t.Optional(t.String()),
             }),
         },
     );

--- a/backend/src/routes/upload.ts
+++ b/backend/src/routes/upload.ts
@@ -692,4 +692,21 @@ export const uploadRoutes = new Elysia()
                 completedPartNumbers: t.Array(t.Number()),
             }),
         },
-    );
+    )
+
+    // Speed test endpoint — accepts and discards a blob for preflight measurement
+    .put('/upload/speedtest', async ({ request }) => {
+        // Consume and discard the body
+        const body = request.body;
+        if (body) {
+            const reader = (body as ReadableStream).getReader();
+            // biome-ignore lint/correctness/noConstantCondition: intentional drain loop
+            while (true) {
+                const { done } = await reader.read();
+                if (done) {
+                    break;
+                }
+            }
+        }
+        return { ok: true };
+    });

--- a/backend/src/routes/upload.ts
+++ b/backend/src/routes/upload.ts
@@ -19,8 +19,19 @@ interface PartInfo {
     maxSize: number;
 }
 
-function calculateOptimalPartSize(fileSize: number): { partSize: number; numParts: number } {
+function calculateOptimalPartSize(
+    fileSize: number,
+    preferredPartSize?: number,
+): { partSize: number; numParts: number } {
     let partSize = DEFAULT_PART_SIZE;
+
+    // Use client-preferred part size if provided and within valid bounds
+    if (preferredPartSize) {
+        if (preferredPartSize >= MIN_PART_SIZE && preferredPartSize <= MAX_PART_SIZE) {
+            partSize = preferredPartSize;
+        }
+    }
+
     let numParts = Math.ceil(fileSize / partSize);
 
     if (numParts > MAX_PARTS) {
@@ -59,7 +70,7 @@ export const uploadRoutes = new Elysia()
     .post(
         '/upload/url',
         async ({ body, request }) => {
-            const { fileSize, encrypted, timeLimit, dlimit } = body;
+            const { fileSize, encrypted, timeLimit, dlimit, preferredPartSize } = body;
             const requestId = randomBytes(4).toString('hex');
 
             logger.info(
@@ -161,7 +172,10 @@ export const uploadRoutes = new Elysia()
             );
 
             if (useMultipart) {
-                const { partSize, numParts } = calculateOptimalPartSize(fileSize);
+                const { partSize, numParts } = calculateOptimalPartSize(
+                    fileSize,
+                    preferredPartSize,
+                );
 
                 logger.info(
                     {
@@ -339,6 +353,7 @@ export const uploadRoutes = new Elysia()
                 encrypted: t.Optional(t.Boolean()),
                 timeLimit: t.Optional(t.Number()),
                 dlimit: t.Optional(t.Number()),
+                preferredPartSize: t.Optional(t.Number()),
             }),
         },
     )

--- a/backend/src/routes/upload.ts
+++ b/backend/src/routes/upload.ts
@@ -695,32 +695,40 @@ export const uploadRoutes = new Elysia()
     )
 
     // Speed test endpoint — accepts and discards a blob for preflight measurement
-    .put('/upload/speedtest', async ({ request }) => {
-        const startTime = Date.now();
-        let totalBytes = 0;
+    .post(
+        '/upload/speedtest',
+        async ({ request }) => {
+            const startTime = Date.now();
+            let totalBytes = 0;
 
-        const body = request.body;
-        if (body) {
-            const reader = (body as ReadableStream).getReader();
-            // biome-ignore lint/correctness/noConstantCondition: intentional drain loop
-            while (true) {
-                const { done, value } = await reader.read();
-                if (done) {
-                    break;
-                }
-                if (value) {
-                    totalBytes += value.length;
+            const body = request.body;
+            if (body) {
+                const reader = (body as ReadableStream).getReader();
+                // biome-ignore lint/correctness/noConstantCondition: intentional drain loop
+                while (true) {
+                    const { done, value } = await reader.read();
+                    if (done) {
+                        break;
+                    }
+                    if (value) {
+                        totalBytes += value.length;
+                    }
                 }
             }
-        }
 
-        const elapsed = (Date.now() - startTime) / 1000;
-        const speedMbps =
-            elapsed > 0 ? Math.round((totalBytes / (1024 * 1024) / elapsed) * 10) / 10 : 0;
-        logger.info(
-            { totalBytes, elapsedMs: Date.now() - startTime, speedMbps },
-            'Speed test completed',
-        );
+            const elapsed = (Date.now() - startTime) / 1000;
+            const speedMbps =
+                elapsed > 0 ? Math.round((totalBytes / (1024 * 1024) / elapsed) * 10) / 10 : 0;
+            logger.info(
+                { totalBytes, elapsedMs: Date.now() - startTime, speedMbps },
+                'Speed test completed',
+            );
 
-        return { ok: true, speedMbps };
-    });
+            return { ok: true, speedMbps };
+        },
+        {
+            // Skip Elysia body parsing — we stream the raw body ourselves
+            // biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op parser
+            parse: () => {},
+        },
+    );

--- a/backend/src/storage/index.ts
+++ b/backend/src/storage/index.ts
@@ -17,6 +17,7 @@ export interface FileMetadata {
     uploadId?: string;
     multipart?: boolean;
     numParts?: number;
+    partSize?: number;
 }
 
 export const storage = {
@@ -54,8 +55,13 @@ export const storage = {
         }
     },
 
-    getSignedMultipartUploadUrl(id: string, uploadId: string, partNumber: number): Promise<string> {
-        return s3Storage.getSignedMultipartUploadUrl(id, uploadId, partNumber);
+    getSignedMultipartUploadUrl(
+        id: string,
+        uploadId: string,
+        partNumber: number,
+        expiresIn?: number,
+    ): Promise<string> {
+        return s3Storage.getSignedMultipartUploadUrl(id, uploadId, partNumber, expiresIn);
     },
 
     completeMultipartUpload(id: string, uploadId: string, parts: CompletedPart[]): Promise<void> {
@@ -112,6 +118,7 @@ export const storage = {
             uploadId: data.uploadId,
             multipart: data.multipart === 'true',
             numParts: data.numParts ? parseInt(data.numParts, 10) : undefined,
+            partSize: data.partSize ? parseInt(data.partSize, 10) : undefined,
         };
     },
 

--- a/bun.lock
+++ b/bun.lock
@@ -85,6 +85,9 @@
       "version": "1.0.0",
     },
   },
+  "trustedDependencies": [
+    "lefthook",
+  ],
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -732,7 +735,7 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
-    "@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
+    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
@@ -812,7 +815,7 @@
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
-    "bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "cachedir": ["cachedir@2.3.0", "", {}, "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw=="],
 

--- a/frontend/src/components/UploadProgress.tsx
+++ b/frontend/src/components/UploadProgress.tsx
@@ -5,7 +5,8 @@ import { formatBytes, formatDuration, formatSpeed } from '@/lib/utils';
 import { useAppStore } from '@/stores/app';
 
 export function UploadProgress() {
-    const { isUploading, uploadProgress, zippingProgress, currentCanceller } = useAppStore();
+    const { isUploading, uploadProgress, zippingProgress, checkingSpeed, currentCanceller } =
+        useAppStore();
 
     if (!isUploading) {
         return null;
@@ -28,7 +29,9 @@ export function UploadProgress() {
 
     // Status text based on connection state
     let statusText = 'Preparing upload...';
-    if (isZipping) {
+    if (checkingSpeed) {
+        statusText = 'Checking speed...';
+    } else if (isZipping) {
         statusText = 'Compressing files...';
     } else if (isOffline) {
         statusText = 'Waiting for connection...';

--- a/frontend/src/components/UploadProgress.tsx
+++ b/frontend/src/components/UploadProgress.tsx
@@ -15,24 +15,40 @@ export function UploadProgress() {
         currentCanceller?.cancel();
     };
 
-    // Determine current phase
     const isZipping = zippingProgress !== null && zippingProgress < 100 && !uploadProgress;
     const isUploading_ = uploadProgress !== null;
-
-    // Show initial state before progress data is available
     const percentage = isZipping ? zippingProgress : (uploadProgress?.percentage ?? 0);
     const loaded = uploadProgress?.loaded ?? 0;
     const total = uploadProgress?.total ?? 0;
     const speed = uploadProgress?.speed ?? 0;
     const remainingTime = uploadProgress?.remainingTime ?? 0;
+    const connectionQuality = uploadProgress?.connectionQuality ?? 'good';
+    const retryCount = uploadProgress?.retryCount ?? 0;
+    const isOffline = uploadProgress?.isOffline ?? false;
 
-    // Status text
+    // Status text based on connection state
     let statusText = 'Preparing upload...';
     if (isZipping) {
         statusText = 'Compressing files...';
+    } else if (isOffline) {
+        statusText = 'Waiting for connection...';
+    } else if (connectionQuality === 'stalled') {
+        statusText = 'Connection stalled...';
+    } else if (retryCount > 0 && connectionQuality !== 'good') {
+        statusText = `Retrying... (${retryCount} ${retryCount === 1 ? 'retry' : 'retries'})`;
     } else if (isUploading_) {
         statusText = 'Uploading...';
     }
+
+    // Connection quality dot color
+    const qualityDotColors: Record<string, string> = {
+        good: 'bg-emerald-500',
+        fair: 'bg-yellow-500',
+        slow: 'bg-orange-500',
+        stalled: 'bg-red-500',
+        offline: 'bg-gray-500',
+    };
+    const dotColor = qualityDotColors[connectionQuality] || 'bg-emerald-500';
 
     return (
         <div className="bg-overlay-subtle border border-border-medium rounded-element p-4">
@@ -46,6 +62,9 @@ export function UploadProgress() {
                     <span className="text-paragraph-sm font-medium text-content-primary">
                         {statusText}
                     </span>
+                    {isUploading_ && !isZipping && (
+                        <span className={`inline-block h-2 w-2 rounded-full ${dotColor}`} />
+                    )}
                 </div>
                 <Button variant="ghost" size="sm" onClick={handleCancel}>
                     <X className="mr-2 h-4 w-4" />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -575,16 +575,20 @@ export async function uploadFiles(
         stream = createFileStream(files, keychain, encrypted);
     }
 
-    // Run preflight speed test to determine optimal part size
-    onSpeedTest?.('started');
-    console.log('[Upload] Running preflight speed test...');
-    const measuredSpeed = await measureUploadSpeed();
-    const speedMbps = Math.round((measuredSpeed / (1024 * 1024)) * 10) / 10;
-    const preferredPartSize = getPreferredPartSize(measuredSpeed);
-    console.log(
-        `[Upload] Preflight result: ${speedMbps} MB/s → ${preferredPartSize ? `${preferredPartSize / (1024 * 1024)}MB` : 'default'} parts`,
-    );
-    onSpeedTest?.('done', speedMbps);
+    // Run preflight speed test for multipart uploads to determine optimal part size.
+    // Single-part uploads (<100MB) don't need this since there's no part sizing decision.
+    let preferredPartSize: number | undefined;
+    if (totalSize > UPLOAD_LIMITS.MULTIPART_THRESHOLD) {
+        onSpeedTest?.('started');
+        console.log('[Upload] Running preflight speed test...');
+        const measuredSpeed = await measureUploadSpeed();
+        const speedMbps = Math.round((measuredSpeed / (1024 * 1024)) * 10) / 10;
+        preferredPartSize = getPreferredPartSize(measuredSpeed);
+        console.log(
+            `[Upload] Preflight result: ${speedMbps} MB/s → ${preferredPartSize ? `${preferredPartSize / (1024 * 1024)}MB` : 'default'} parts`,
+        );
+        onSpeedTest?.('done', speedMbps);
+    }
 
     // Request upload URLs
     const uploadResponse = await fetch(`${API_BASE_URL}/upload/url`, {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3,7 +3,7 @@
  * Implements resilient direct-to-cloudflare multipart uploads
  */
 
-import { UPLOAD_LIMITS } from '@bolter/shared';
+import { PART_SIZE_TIERS, UPLOAD_LIMITS } from '@bolter/shared';
 import {
     arrayToB64,
     b64ToArray,
@@ -35,6 +35,43 @@ const MAX_RETRIES = 10;
 const RETRY_DELAY_BASE = 2000; // 2 seconds
 const MAX_RETRY_DELAY = 60000; // 60 seconds
 const STALL_TIMEOUT = 60_000; // Abort upload part if no progress for 60 seconds
+
+// Speed persistence via localStorage
+const SPEED_STORAGE_KEY = 'bolter:uploadSpeed';
+
+function getObservedSpeed(): number {
+    try {
+        const stored = localStorage.getItem(SPEED_STORAGE_KEY);
+        return stored ? Number(stored) : 0;
+    } catch {
+        return 0;
+    }
+}
+
+function updateObservedSpeed(speed: number): void {
+    try {
+        const current = getObservedSpeed();
+        // Exponential moving average (alpha = 0.3)
+        const smoothed = current === 0 ? speed : current * 0.7 + speed * 0.3;
+        localStorage.setItem(SPEED_STORAGE_KEY, smoothed.toString());
+    } catch {
+        // Ignore storage errors
+    }
+}
+
+function getPreferredPartSize(): number | undefined {
+    const speed = getObservedSpeed();
+    if (speed === 0) {
+        return undefined; // No data yet, use server default
+    }
+
+    for (const tier of PART_SIZE_TIERS) {
+        if (speed >= tier.minSpeed) {
+            return tier.partSize;
+        }
+    }
+    return PART_SIZE_TIERS[PART_SIZE_TIERS.length - 1].partSize;
+}
 
 // Adaptive concurrency based on file size
 // With backpressure, memory is bounded to ~(concurrency + 1) * partSize
@@ -436,6 +473,7 @@ export async function uploadFiles(
             encrypted,
             timeLimit,
             dlimit: downloadLimit,
+            preferredPartSize: getPreferredPartSize(),
         }),
     });
 
@@ -776,6 +814,9 @@ async function uploadMultipartStream(
     // Track actual uploaded part sizes for pre-completion consistency check
     const uploadedPartSizes: Record<number, number> = {};
 
+    // Track per-part start times for speed measurement
+    const partStartTimes: Record<number, number> = {};
+
     // Promise to signal when all uploads are done
     let resolveAllDone: () => void;
     const allDonePromise = new Promise<void>((resolve) => {
@@ -792,6 +833,7 @@ async function uploadMultipartStream(
             console.log(
                 `[Upload] Part ${partNum} starting (${(partBlob.size / (1024 * 1024)).toFixed(1)}MB)`,
             );
+            partStartTimes[partNum] = Date.now();
             const result = await uploadPartWithRetry(
                 partBlob,
                 partUrl,
@@ -799,6 +841,10 @@ async function uploadMultipartStream(
                 (loaded) => onProgress(partNum, loaded),
                 canceller,
             );
+            const elapsed = (Date.now() - partStartTimes[partNum]) / 1000;
+            if (elapsed > 0) {
+                updateObservedSpeed(partBlob.size / elapsed);
+            }
             completedParts.push(result);
             uploadedPartSizes[partNum] = partBlob.size;
             console.log(`[Upload] Part ${partNum} complete`);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -44,8 +44,9 @@ const MAX_RETRY_DELAY = 60000; // 60 seconds
 const STALL_TIMEOUT = 60_000; // Abort upload part if no progress for 60 seconds
 
 // Preflight speed test configuration
-const PREFLIGHT_SIZE = 500 * 1024 * 1024; // 500MB test payload
-const PREFLIGHT_TIMEOUT = 10_000; // Run for up to 10 seconds
+const SPEEDTEST_PART_SIZE = 100 * 1024 * 1024; // 100MB per part
+const SPEEDTEST_PARTS = 5; // 5 concurrent parts
+const SPEEDTEST_TIMEOUT = 10_000; // Run for up to 10 seconds
 
 function waitForOnline(): Promise<void> {
     if (navigator.onLine) {
@@ -58,70 +59,92 @@ function waitForOnline(): Promise<void> {
 }
 
 /**
- * Measure upload speed with a preflight test.
- * Gets a pre-signed S3 URL from the backend, uploads a blob directly to S3
- * for up to 10 seconds, then cleans up the test object.
+ * Measure upload speed with a multipart preflight test.
+ * Uploads 5x100MB parts concurrently to S3 for up to 10 seconds,
+ * measuring aggregate throughput. This mirrors the actual upload
+ * path and concurrency to give a realistic speed reading.
  * Returns measured speed in bytes/second, or 0 on failure.
  */
 async function measureUploadSpeed(): Promise<number> {
     let testId: string | null = null;
+    let uploadId: string | null = null;
     try {
-        // Get a pre-signed S3 URL for the speed test
+        // Get pre-signed S3 URLs for a multipart speed test
         const res = await fetch(`${API_BASE_URL}/upload/speedtest`, { method: 'POST' });
         if (!res.ok) {
             console.warn(`[Upload] Speed test setup failed: HTTP ${res.status}`);
             return 0;
         }
-        const { url, testId: id } = await res.json();
-        testId = id;
-        if (!url) {
-            console.warn('[Upload] Speed test: no URL returned');
+        const data = await res.json();
+        testId = data.testId;
+        uploadId = data.uploadId;
+        if (!data.parts || data.parts.length === 0) {
+            console.warn('[Upload] Speed test: no part URLs returned');
             return 0;
         }
 
-        // Upload a zero-filled blob directly to S3 (no body limit)
-        const blob = new Blob([new ArrayBuffer(PREFLIGHT_SIZE)]);
-        let uploadedBytes = 0;
+        const blob = new Blob([new ArrayBuffer(SPEEDTEST_PART_SIZE)]);
+        const partBytes: number[] = new Array(data.parts.length).fill(0);
+        const xhrs: XMLHttpRequest[] = [];
         const startTime = Date.now();
+        let settled = false;
 
         const speed = await new Promise<number>((resolve) => {
-            const xhr = new XMLHttpRequest();
+            const finish = () => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                const totalBytes = partBytes.reduce((a, b) => a + b, 0);
+                const elapsed = (Date.now() - startTime) / 1000;
+                resolve(elapsed > 0 ? totalBytes / elapsed : 0);
+            };
+
+            // Abort all XHRs after timeout
             const timeout = setTimeout(() => {
-                xhr.abort();
-                const elapsed = (Date.now() - startTime) / 1000;
-                resolve(elapsed > 0 ? uploadedBytes / elapsed : 0);
-            }, PREFLIGHT_TIMEOUT);
-
-            xhr.upload.addEventListener('progress', (e) => {
-                if (e.lengthComputable) {
-                    uploadedBytes = e.loaded;
+                for (const xhr of xhrs) {
+                    if (xhr.readyState !== XMLHttpRequest.DONE) {
+                        xhr.abort();
+                    }
                 }
-            });
+                finish();
+            }, SPEEDTEST_TIMEOUT);
 
-            xhr.addEventListener('loadend', () => {
-                clearTimeout(timeout);
-                const elapsed = (Date.now() - startTime) / 1000;
-                if (xhr.status >= 200 && xhr.status < 300) {
-                    resolve(elapsed > 0 ? blob.size / elapsed : 0);
-                } else if (xhr.status !== 0) {
-                    console.warn(
-                        `[Upload] Speed test upload failed: HTTP ${xhr.status} ${xhr.statusText}`,
-                    );
-                    resolve(0);
-                } else {
-                    // status 0 = aborted by our timeout, use tracked bytes
-                    resolve(elapsed > 0 ? uploadedBytes / elapsed : 0);
-                }
-            });
+            let completedCount = 0;
 
-            xhr.addEventListener('error', () => {
-                clearTimeout(timeout);
-                console.warn(`[Upload] Speed test network error (status=${xhr.status})`);
-                resolve(0);
-            });
+            for (let i = 0; i < data.parts.length; i++) {
+                const xhr = new XMLHttpRequest();
+                xhrs.push(xhr);
 
-            xhr.open('PUT', url);
-            xhr.send(blob);
+                xhr.upload.addEventListener('progress', (e) => {
+                    if (e.lengthComputable) {
+                        partBytes[i] = e.loaded;
+                    }
+                });
+
+                xhr.addEventListener('loadend', () => {
+                    if (xhr.status >= 200 && xhr.status < 300) {
+                        partBytes[i] = SPEEDTEST_PART_SIZE;
+                    }
+                    completedCount++;
+                    // All parts done before timeout
+                    if (completedCount === data.parts.length) {
+                        clearTimeout(timeout);
+                        finish();
+                    }
+                });
+
+                xhr.addEventListener('error', () => {
+                    completedCount++;
+                    if (completedCount === data.parts.length) {
+                        clearTimeout(timeout);
+                        finish();
+                    }
+                });
+
+                xhr.open('PUT', data.parts[i].url);
+                xhr.send(blob);
+            }
         });
 
         return speed;
@@ -129,12 +152,12 @@ async function measureUploadSpeed(): Promise<number> {
         console.warn('[Upload] Speed test exception:', e);
         return 0;
     } finally {
-        // Clean up the test object from S3
+        // Clean up the test multipart upload from S3
         if (testId) {
             fetch(`${API_BASE_URL}/upload/speedtest/cleanup`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ testId }),
+                body: JSON.stringify({ testId, uploadId }),
             }).catch(() => {
                 // Best-effort cleanup
             });
@@ -157,13 +180,13 @@ function getPreferredPartSize(speed: number): number | undefined {
 
 // Adaptive concurrency based on file size
 // With backpressure, memory is bounded to ~(concurrency + 1) * partSize
-// e.g., concurrency 3 with 200MB parts = max ~800MB buffered
+// e.g., concurrency 5 with 200MB parts = max ~1.2GB buffered
 function getConcurrentUploads(fileSize: number): number {
     const GB = 1024 * 1024 * 1024;
     if (fileSize > 50 * GB) {
-        return 2; // > 50GB: conservative
+        return 3; // > 50GB: conservative
     }
-    return 3; // default: 3 concurrent uploads
+    return 5; // default: 5 concurrent uploads
 }
 
 export interface UploadProgress {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -511,34 +511,13 @@ export async function uploadFiles(
 
     // Track progress
     const partProgress: Record<number, number> = {};
-    const updateProgress = (partNum: number, loaded: number) => {
-        partProgress[partNum] = loaded;
+
+    // Emit a progress snapshot to the UI
+    const emitProgress = () => {
         const totalLoaded = Object.values(partProgress).reduce((sum, p) => sum + p, 0);
-
-        const now = Date.now();
-        const elapsed = (now - lastProgressTime) / 1000;
-        const bytesInPeriod = totalLoaded - lastProgressBytes;
-        const instantSpeed = elapsed > 0 ? bytesInPeriod / elapsed : 0;
-
-        // Track last time we saw actual bytes moving
-        if (bytesInPeriod > 0) {
-            lastPartProgressTime = now;
-        }
-
-        // Update speed/time calculation once per second with smoothing
-        const displayElapsed = (now - lastDisplayTime) / 1000;
-        if (displayElapsed >= 1 || lastDisplayTime === startTime) {
-            // Exponential moving average for smooth speed (alpha = 0.3)
-            smoothedSpeed =
-                smoothedSpeed === 0 ? instantSpeed : smoothedSpeed * 0.7 + instantSpeed * 0.3;
-            smoothedRemaining = smoothedSpeed > 0 ? (totalSize - totalLoaded) / smoothedSpeed : 0;
-            lastDisplayTime = now;
-            lastProgressTime = now;
-            lastProgressBytes = totalLoaded;
-        }
-
-        // Compute connection quality
         const isOffline = !navigator.onLine;
+        const now = Date.now();
+
         let connectionQuality: UploadProgress['connectionQuality'];
         if (isOffline) {
             connectionQuality = 'offline';
@@ -552,7 +531,6 @@ export async function uploadFiles(
             connectionQuality = 'good';
         }
 
-        // Always update progress bar, but speed/time stay stable between updates
         onProgress?.({
             loaded: Math.min(totalLoaded, totalSize),
             total: totalSize,
@@ -565,175 +543,217 @@ export async function uploadFiles(
         });
     };
 
+    const updateProgress = (partNum: number, loaded: number) => {
+        partProgress[partNum] = loaded;
+        const totalLoaded = Object.values(partProgress).reduce((sum, p) => sum + p, 0);
+
+        const now = Date.now();
+        const elapsed = (now - lastProgressTime) / 1000;
+        const bytesInPeriod = totalLoaded - lastProgressBytes;
+        const instantSpeed = elapsed > 0 ? bytesInPeriod / elapsed : 0;
+
+        if (bytesInPeriod > 0) {
+            lastPartProgressTime = now;
+        }
+
+        const displayElapsed = (now - lastDisplayTime) / 1000;
+        if (displayElapsed >= 1 || lastDisplayTime === startTime) {
+            smoothedSpeed =
+                smoothedSpeed === 0 ? instantSpeed : smoothedSpeed * 0.7 + instantSpeed * 0.3;
+            smoothedRemaining = smoothedSpeed > 0 ? (totalSize - totalLoaded) / smoothedSpeed : 0;
+            lastDisplayTime = now;
+            lastProgressTime = now;
+            lastProgressBytes = totalLoaded;
+        }
+
+        emitProgress();
+    };
+
+    // Re-evaluate connection quality on connectivity changes and periodically
+    // so offline/stalled states show immediately even when no bytes are flowing
+    const statusPollInterval = setInterval(emitProgress, 1000);
+    const onConnectivityChange = () => emitProgress();
+    window.addEventListener('online', onConnectivityChange);
+    window.addEventListener('offline', onConnectivityChange);
+    const cleanupStatusPoll = () => {
+        clearInterval(statusPollInterval);
+        window.removeEventListener('online', onConnectivityChange);
+        window.removeEventListener('offline', onConnectivityChange);
+    };
+
     let uploadResult: { actualSize: number; parts?: { PartNumber: number; ETag: string }[] };
 
-    if (uploadInfo.multipart && uploadInfo.parts) {
-        // Persist upload state for resumability
-        // Store the raw (pre-encryption) file size for matching against File.size on resume
-        const rawFileSize = files.length === 1 ? files[0].size : totalInputSize;
-        // Calculate plaintext bytes per encrypted part
-        // Each ECE record: plaintext ECE_RECORD_SIZE → encrypted ECE_RECORD_SIZE + 17 (tag + delimiter)
-        const encryptedRecordSize = ECE_RECORD_SIZE + 17;
-        const plaintextPartSize = encrypted
-            ? Math.floor((uploadInfo.partSize || 0) / encryptedRecordSize) * ECE_RECORD_SIZE
-            : uploadInfo.partSize || 0;
-        const persistState: PersistedUpload = {
-            fileId: uploadInfo.id,
-            uploadId: uploadInfo.uploadId || '',
-            ownerToken: uploadInfo.owner,
-            fileName: files.length === 1 ? files[0].name : `${files.length}_files.zip`,
-            fileSize: rawFileSize,
-            fileLastModified: files.length === 1 ? files[0].lastModified : 0,
-            encrypted,
-            partSize: uploadInfo.partSize || 0,
-            plaintextPartSize,
-            completedParts: [],
-            totalParts: uploadInfo.parts.length,
-            secretKeyB64: encrypted ? keychain.secretKeyB64 : undefined,
-            timeLimit: timeLimit || 86400,
-            downloadLimit: downloadLimit || 1,
-            createdAt: Date.now(),
-        };
-        saveUploadState(persistState).catch((e) =>
-            console.warn('[Upload] Failed to persist upload state:', e),
-        );
-
-        // Multipart upload
-        const multipartResult = await uploadMultipartStream(
-            stream,
-            uploadInfo,
-            updateProgress,
-            canceller,
-            onError,
-            totalSize,
-            () => {
-                totalRetryCount++;
-                // Trigger a progress update so the UI reflects the new retry count.
-                // Re-emit part 1's current tracked bytes (or 0 if not started yet).
-                const part1Bytes = partProgress[1] ?? 0;
-                updateProgress(1, part1Bytes);
-            },
-            uploadInfo.id,
-        );
-
-        // Handle fallback: stream produced too little data for multipart
-        if ('fallbackBlob' in multipartResult) {
-            console.log(
-                `[Upload] Falling back to single-part upload (${(multipartResult.fallbackBlob.size / 1024).toFixed(1)}KB)`,
+    try {
+        if (uploadInfo.multipart && uploadInfo.parts) {
+            // Persist upload state for resumability
+            // Store the raw (pre-encryption) file size for matching against File.size on resume
+            const rawFileSize = files.length === 1 ? files[0].size : totalInputSize;
+            // Calculate plaintext bytes per encrypted part
+            // Each ECE record: plaintext ECE_RECORD_SIZE → encrypted ECE_RECORD_SIZE + 17 (tag + delimiter)
+            const encryptedRecordSize = ECE_RECORD_SIZE + 17;
+            const plaintextPartSize = encrypted
+                ? Math.floor((uploadInfo.partSize || 0) / encryptedRecordSize) * ECE_RECORD_SIZE
+                : uploadInfo.partSize || 0;
+            const persistState: PersistedUpload = {
+                fileId: uploadInfo.id,
+                uploadId: uploadInfo.uploadId || '',
+                ownerToken: uploadInfo.owner,
+                fileName: files.length === 1 ? files[0].name : `${files.length}_files.zip`,
+                fileSize: rawFileSize,
+                fileLastModified: files.length === 1 ? files[0].lastModified : 0,
+                encrypted,
+                partSize: uploadInfo.partSize || 0,
+                plaintextPartSize,
+                completedParts: [],
+                totalParts: uploadInfo.parts.length,
+                secretKeyB64: encrypted ? keychain.secretKeyB64 : undefined,
+                timeLimit: timeLimit || 86400,
+                downloadLimit: downloadLimit || 1,
+                createdAt: Date.now(),
+            };
+            saveUploadState(persistState).catch((e) =>
+                console.warn('[Upload] Failed to persist upload state:', e),
             );
 
-            // Abort the multipart upload
-            if (uploadInfo.uploadId) {
-                await abortMultipartUpload(uploadInfo.id, uploadInfo.uploadId);
+            // Multipart upload
+            const multipartResult = await uploadMultipartStream(
+                stream,
+                uploadInfo,
+                updateProgress,
+                canceller,
+                onError,
+                totalSize,
+                () => {
+                    totalRetryCount++;
+                    // Trigger a progress update so the UI reflects the new retry count.
+                    // Re-emit part 1's current tracked bytes (or 0 if not started yet).
+                    const part1Bytes = partProgress[1] ?? 0;
+                    updateProgress(1, part1Bytes);
+                },
+                uploadInfo.id,
+            );
+
+            // Handle fallback: stream produced too little data for multipart
+            if ('fallbackBlob' in multipartResult) {
+                console.log(
+                    `[Upload] Falling back to single-part upload (${(multipartResult.fallbackBlob.size / 1024).toFixed(1)}KB)`,
+                );
+
+                // Abort the multipart upload
+                if (uploadInfo.uploadId) {
+                    await abortMultipartUpload(uploadInfo.id, uploadInfo.uploadId);
+                }
+
+                // Request a new single-part upload URL
+                const fallbackResponse = await fetch(`${API_BASE_URL}/upload/url`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        fileSize: multipartResult.fallbackBlob.size,
+                        encrypted,
+                        timeLimit,
+                        dlimit: downloadLimit,
+                    }),
+                });
+
+                if (!fallbackResponse.ok) {
+                    throw new Error(`HTTP ${fallbackResponse.status}`);
+                }
+
+                const fallbackInfo: UploadUrlResponse = await fallbackResponse.json();
+                if (!fallbackInfo.useSignedUrl) {
+                    throw new Error('Pre-signed URLs not available for fallback');
+                }
+
+                // Use the new file ID and owner from the fallback response
+                uploadInfo = fallbackInfo;
+
+                uploadResult = await uploadSinglePart(
+                    multipartResult.fallbackBlob,
+                    fallbackInfo.url,
+                    (loaded) => updateProgress(1, loaded),
+                    canceller,
+                );
+            } else {
+                uploadResult = multipartResult;
             }
-
-            // Request a new single-part upload URL
-            const fallbackResponse = await fetch(`${API_BASE_URL}/upload/url`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    fileSize: multipartResult.fallbackBlob.size,
-                    encrypted,
-                    timeLimit,
-                    dlimit: downloadLimit,
-                }),
-            });
-
-            if (!fallbackResponse.ok) {
-                throw new Error(`HTTP ${fallbackResponse.status}`);
-            }
-
-            const fallbackInfo: UploadUrlResponse = await fallbackResponse.json();
-            if (!fallbackInfo.useSignedUrl) {
-                throw new Error('Pre-signed URLs not available for fallback');
-            }
-
-            // Use the new file ID and owner from the fallback response
-            uploadInfo = fallbackInfo;
-
+        } else {
+            // Single part upload
+            const blob = await new Response(stream).blob();
             uploadResult = await uploadSinglePart(
-                multipartResult.fallbackBlob,
-                fallbackInfo.url,
+                blob,
+                uploadInfo.url,
                 (loaded) => updateProgress(1, loaded),
                 canceller,
             );
-        } else {
-            uploadResult = multipartResult;
         }
-    } else {
-        // Single part upload
-        const blob = await new Response(stream).blob();
-        uploadResult = await uploadSinglePart(
-            blob,
-            uploadInfo.url,
-            (loaded) => updateProgress(1, loaded),
-            canceller,
-        );
-    }
 
-    if (canceller.cancelled) {
-        if (uploadInfo.multipart && uploadInfo.uploadId) {
-            await abortMultipartUpload(uploadInfo.id, uploadInfo.uploadId);
+        if (canceller.cancelled) {
+            if (uploadInfo.multipart && uploadInfo.uploadId) {
+                await abortMultipartUpload(uploadInfo.id, uploadInfo.uploadId);
+                deleteUploadState(uploadInfo.id).catch(() => {
+                    // Intentionally ignored — best-effort cleanup
+                });
+            }
+            throw new Error('Upload cancelled');
+        }
+
+        // Complete the upload
+        const metadataString = encrypted
+            ? arrayToB64(await keychain.encryptMetadata(metadata))
+            : btoa(unescape(encodeURIComponent(JSON.stringify(metadata))));
+
+        const completeResponse = await fetchWithRetry(`${API_BASE_URL}/upload/complete`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                id: uploadInfo.id,
+                metadata: metadataString,
+                ...(encrypted && { authKey: await keychain.authKeyB64() }),
+                actualSize: uploadResult.actualSize || totalSize,
+                ...(uploadResult.parts && { parts: uploadResult.parts }),
+            }),
+        });
+
+        if (!completeResponse.ok) {
+            const errorText = await completeResponse.text();
+            const err = new Error(`Failed to complete upload: ${errorText}`);
+            captureError(err, {
+                operation: 'upload.complete',
+                extra: {
+                    fileId: uploadInfo.id,
+                    httpStatus: completeResponse.status,
+                    encrypted,
+                    multipart: uploadInfo.multipart,
+                    totalSize,
+                    responsePreview: errorText.substring(0, 200),
+                },
+            });
+            throw err;
+        }
+
+        const _completeInfo = await completeResponse.json();
+
+        // Clean up persisted upload state
+        if (uploadInfo.multipart) {
             deleteUploadState(uploadInfo.id).catch(() => {
                 // Intentionally ignored — best-effort cleanup
             });
         }
-        throw new Error('Upload cancelled');
-    }
 
-    // Complete the upload
-    const metadataString = encrypted
-        ? arrayToB64(await keychain.encryptMetadata(metadata))
-        : btoa(unescape(encodeURIComponent(JSON.stringify(metadata))));
+        // Always use frontend origin for download URL (backend may return its own URL)
+        // Don't include hash here - ShareDialog will append the secretKey
+        const downloadUrl = `${window.location.origin}/download/${uploadInfo.id}`;
 
-    const completeResponse = await fetchWithRetry(`${API_BASE_URL}/upload/complete`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
+        return {
             id: uploadInfo.id,
-            metadata: metadataString,
-            ...(encrypted && { authKey: await keychain.authKeyB64() }),
-            actualSize: uploadResult.actualSize || totalSize,
-            ...(uploadResult.parts && { parts: uploadResult.parts }),
-        }),
-    });
-
-    if (!completeResponse.ok) {
-        const errorText = await completeResponse.text();
-        const err = new Error(`Failed to complete upload: ${errorText}`);
-        captureError(err, {
-            operation: 'upload.complete',
-            extra: {
-                fileId: uploadInfo.id,
-                httpStatus: completeResponse.status,
-                encrypted,
-                multipart: uploadInfo.multipart,
-                totalSize,
-                responsePreview: errorText.substring(0, 200),
-            },
-        });
-        throw err;
+            url: downloadUrl,
+            ownerToken: uploadInfo.owner,
+            duration: Date.now() - startTime,
+        };
+    } finally {
+        cleanupStatusPoll();
     }
-
-    const _completeInfo = await completeResponse.json();
-
-    // Clean up persisted upload state
-    if (uploadInfo.multipart) {
-        deleteUploadState(uploadInfo.id).catch(() => {
-            // Intentionally ignored — best-effort cleanup
-        });
-    }
-
-    // Always use frontend origin for download URL (backend may return its own URL)
-    // Don't include hash here - ShareDialog will append the secretKey
-    const downloadUrl = `${window.location.origin}/download/${uploadInfo.id}`;
-
-    return {
-        id: uploadInfo.id,
-        url: downloadUrl,
-        ownerToken: uploadInfo.owner,
-        duration: Date.now() - startTime,
-    };
 }
 
 /**

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -59,22 +59,34 @@ function waitForOnline(): Promise<void> {
 
 /**
  * Measure upload speed with a preflight test.
- * Uploads a 20MB random payload for up to 10 seconds,
- * then returns the measured speed in bytes/second.
- * Returns 0 if the test fails (server will use default part size).
+ * Gets a pre-signed S3 URL from the backend, uploads a blob directly to S3
+ * for up to 10 seconds, then cleans up the test object.
+ * Returns measured speed in bytes/second, or 0 on failure.
  */
 async function measureUploadSpeed(): Promise<number> {
+    let testId: string | null = null;
     try {
-        // Create a zero-filled blob — content doesn't matter for speed measurement,
-        // and this avoids the cost of filling 500MB with random data
+        // Get a pre-signed S3 URL for the speed test
+        const res = await fetch(`${API_BASE_URL}/upload/speedtest`, { method: 'POST' });
+        if (!res.ok) {
+            console.warn(`[Upload] Speed test setup failed: HTTP ${res.status}`);
+            return 0;
+        }
+        const { url, testId: id } = await res.json();
+        testId = id;
+        if (!url) {
+            console.warn('[Upload] Speed test: no URL returned');
+            return 0;
+        }
+
+        // Upload a zero-filled blob directly to S3 (no body limit)
         const blob = new Blob([new ArrayBuffer(PREFLIGHT_SIZE)]);
         let uploadedBytes = 0;
         const startTime = Date.now();
 
-        return await new Promise<number>((resolve) => {
+        const speed = await new Promise<number>((resolve) => {
             const xhr = new XMLHttpRequest();
             const timeout = setTimeout(() => {
-                // Time's up — calculate speed from what we managed to send
                 xhr.abort();
                 const elapsed = (Date.now() - startTime) / 1000;
                 resolve(elapsed > 0 ? uploadedBytes / elapsed : 0);
@@ -92,13 +104,12 @@ async function measureUploadSpeed(): Promise<number> {
                 if (xhr.status >= 200 && xhr.status < 300) {
                     resolve(elapsed > 0 ? blob.size / elapsed : 0);
                 } else if (xhr.status !== 0) {
-                    // Non-zero status = server responded with error
                     console.warn(
-                        `[Upload] Speed test failed: HTTP ${xhr.status} ${xhr.statusText}`,
+                        `[Upload] Speed test upload failed: HTTP ${xhr.status} ${xhr.statusText}`,
                     );
                     resolve(0);
                 } else {
-                    // status 0 = aborted by timeout (expected), use tracked bytes
+                    // status 0 = aborted by our timeout, use tracked bytes
                     resolve(elapsed > 0 ? uploadedBytes / elapsed : 0);
                 }
             });
@@ -109,13 +120,25 @@ async function measureUploadSpeed(): Promise<number> {
                 resolve(0);
             });
 
-            xhr.open('POST', `${API_BASE_URL}/upload/speedtest`);
-            xhr.setRequestHeader('Content-Type', 'application/octet-stream');
+            xhr.open('PUT', url);
             xhr.send(blob);
         });
+
+        return speed;
     } catch (e) {
         console.warn('[Upload] Speed test exception:', e);
         return 0;
+    } finally {
+        // Clean up the test object from S3
+        if (testId) {
+            fetch(`${API_BASE_URL}/upload/speedtest/cleanup`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ testId }),
+            }).catch(() => {
+                // Best-effort cleanup
+            });
+        }
     }
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -100,6 +100,9 @@ export interface UploadProgress {
     percentage: number;
     speed: number; // bytes per second
     remainingTime: number; // seconds
+    retryCount: number;
+    isOffline: boolean;
+    connectionQuality: 'good' | 'fair' | 'slow' | 'stalled' | 'offline';
 }
 
 export interface UploadResult {
@@ -396,6 +399,8 @@ export async function uploadFiles(
     let lastDisplayTime = startTime;
     let smoothedSpeed = 0;
     let smoothedRemaining = 0;
+    let totalRetryCount = 0;
+    let lastPartProgressTime = Date.now();
 
     // Determine upload strategy for multi-file uploads
     const isMultiFile = files.length > 1;
@@ -508,6 +513,11 @@ export async function uploadFiles(
         const bytesInPeriod = totalLoaded - lastProgressBytes;
         const instantSpeed = elapsed > 0 ? bytesInPeriod / elapsed : 0;
 
+        // Track last time we saw actual bytes moving
+        if (bytesInPeriod > 0) {
+            lastPartProgressTime = now;
+        }
+
         // Update speed/time calculation once per second with smoothing
         const displayElapsed = (now - lastDisplayTime) / 1000;
         if (displayElapsed >= 1 || lastDisplayTime === startTime) {
@@ -520,6 +530,21 @@ export async function uploadFiles(
             lastProgressBytes = totalLoaded;
         }
 
+        // Compute connection quality
+        const isOffline = !navigator.onLine;
+        let connectionQuality: UploadProgress['connectionQuality'];
+        if (isOffline) {
+            connectionQuality = 'offline';
+        } else if (smoothedSpeed === 0 || now - lastPartProgressTime > 10000) {
+            connectionQuality = 'stalled';
+        } else if (smoothedSpeed < 1 * 1024 * 1024) {
+            connectionQuality = 'slow';
+        } else if (smoothedSpeed < 10 * 1024 * 1024) {
+            connectionQuality = 'fair';
+        } else {
+            connectionQuality = 'good';
+        }
+
         // Always update progress bar, but speed/time stay stable between updates
         onProgress?.({
             loaded: Math.min(totalLoaded, totalSize),
@@ -527,6 +552,9 @@ export async function uploadFiles(
             percentage: Math.min((totalLoaded / totalSize) * 100, 100),
             speed: smoothedSpeed,
             remainingTime: smoothedRemaining,
+            retryCount: totalRetryCount,
+            isOffline,
+            connectionQuality,
         });
     };
 
@@ -541,6 +569,13 @@ export async function uploadFiles(
             canceller,
             onError,
             totalSize,
+            () => {
+                totalRetryCount++;
+                // Trigger a progress update so the UI reflects the new retry count.
+                // Re-emit part 1's current tracked bytes (or 0 if not started yet).
+                const part1Bytes = partProgress[1] ?? 0;
+                updateProgress(1, part1Bytes);
+            },
         );
 
         // Handle fallback: stream produced too little data for multipart
@@ -794,6 +829,7 @@ async function uploadMultipartStream(
     canceller: Canceller,
     onError?: (error: UploadError) => void,
     totalFileSize?: number,
+    onRetry?: () => void,
 ): Promise<MultipartStreamResult> {
     const { parts, partSize } = uploadInfo;
     if (!parts || !partSize) {
@@ -850,6 +886,8 @@ async function uploadMultipartStream(
                 partNum,
                 (loaded) => onProgress(partNum, loaded),
                 canceller,
+                0,
+                onRetry,
             );
             const elapsed = (Date.now() - partStartTimes[partNum]) / 1000;
             if (elapsed > 0) {
@@ -1208,6 +1246,7 @@ async function uploadPartWithRetry(
     onProgress: (loaded: number) => void,
     canceller: Canceller,
     retryCount = 0,
+    onRetry?: () => void,
 ): Promise<{ PartNumber: number; ETag: string }> {
     try {
         return await uploadPart(blob, url, partNumber, onProgress, canceller);
@@ -1235,6 +1274,8 @@ async function uploadPartWithRetry(
 
             console.log(`[Upload] Retrying part ${partNumber} in ${(delay / 1000).toFixed(1)}s...`);
 
+            onRetry?.();
+
             await new Promise((resolve) => setTimeout(resolve, delay));
 
             if (canceller.cancelled) {
@@ -1249,6 +1290,7 @@ async function uploadPartWithRetry(
                 onProgress,
                 canceller,
                 retryCount + 1,
+                onRetry,
             );
         }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -43,28 +43,9 @@ const RETRY_DELAY_BASE = 2000; // 2 seconds
 const MAX_RETRY_DELAY = 60000; // 60 seconds
 const STALL_TIMEOUT = 60_000; // Abort upload part if no progress for 60 seconds
 
-// Speed persistence via localStorage
-const SPEED_STORAGE_KEY = 'bolter:uploadSpeed';
-
-function getObservedSpeed(): number {
-    try {
-        const stored = localStorage.getItem(SPEED_STORAGE_KEY);
-        return stored ? Number(stored) : 0;
-    } catch {
-        return 0;
-    }
-}
-
-function updateObservedSpeed(speed: number): void {
-    try {
-        const current = getObservedSpeed();
-        // Exponential moving average (alpha = 0.3)
-        const smoothed = current === 0 ? speed : current * 0.7 + speed * 0.3;
-        localStorage.setItem(SPEED_STORAGE_KEY, smoothed.toString());
-    } catch {
-        // Ignore storage errors
-    }
-}
+// Preflight speed test configuration
+const PREFLIGHT_SIZE = 20 * 1024 * 1024; // 20MB test payload
+const PREFLIGHT_TIMEOUT = 10_000; // Run for up to 10 seconds
 
 function waitForOnline(): Promise<void> {
     if (navigator.onLine) {
@@ -76,10 +57,57 @@ function waitForOnline(): Promise<void> {
     });
 }
 
-function getPreferredPartSize(): number | undefined {
-    const speed = getObservedSpeed();
+/**
+ * Measure upload speed with a preflight test.
+ * Uploads a 20MB random payload for up to 10 seconds,
+ * then returns the measured speed in bytes/second.
+ * Returns 0 if the test fails (server will use default part size).
+ */
+async function measureUploadSpeed(): Promise<number> {
+    try {
+        const blob = new Blob([crypto.getRandomValues(new Uint8Array(PREFLIGHT_SIZE))]);
+        let uploadedBytes = 0;
+        const startTime = Date.now();
+
+        return await new Promise<number>((resolve) => {
+            const xhr = new XMLHttpRequest();
+            const timeout = setTimeout(() => {
+                // Time's up — calculate speed from what we managed to send
+                xhr.abort();
+                const elapsed = (Date.now() - startTime) / 1000;
+                resolve(elapsed > 0 ? uploadedBytes / elapsed : 0);
+            }, PREFLIGHT_TIMEOUT);
+
+            xhr.upload.addEventListener('progress', (e) => {
+                if (e.lengthComputable) {
+                    uploadedBytes = e.loaded;
+                }
+            });
+
+            xhr.addEventListener('loadend', () => {
+                clearTimeout(timeout);
+                const elapsed = (Date.now() - startTime) / 1000;
+                // Use total blob size on success, tracked bytes on abort
+                const bytes = xhr.status >= 200 && xhr.status < 300 ? blob.size : uploadedBytes;
+                resolve(elapsed > 0 ? bytes / elapsed : 0);
+            });
+
+            xhr.addEventListener('error', () => {
+                clearTimeout(timeout);
+                resolve(0);
+            });
+
+            xhr.open('PUT', `${API_BASE_URL}/upload/speedtest`);
+            xhr.send(blob);
+        });
+    } catch {
+        return 0;
+    }
+}
+
+function getPreferredPartSize(speed: number): number | undefined {
     if (speed === 0) {
-        return undefined; // No data yet, use server default
+        return undefined;
     }
 
     for (const tier of PART_SIZE_TIERS) {
@@ -486,6 +514,16 @@ export async function uploadFiles(
         stream = createFileStream(files, keychain, encrypted);
     }
 
+    // Run preflight speed test to determine optimal part size
+    console.log('[Upload] Running preflight speed test...');
+    const measuredSpeed = await measureUploadSpeed();
+    const preferredPartSize = getPreferredPartSize(measuredSpeed);
+    if (measuredSpeed > 0) {
+        console.log(
+            `[Upload] Preflight: ${(measuredSpeed / (1024 * 1024)).toFixed(1)} MB/s → ${preferredPartSize ? `${preferredPartSize / (1024 * 1024)}MB` : 'default'} parts`,
+        );
+    }
+
     // Request upload URLs
     const uploadResponse = await fetch(`${API_BASE_URL}/upload/url`, {
         method: 'POST',
@@ -495,7 +533,7 @@ export async function uploadFiles(
             encrypted,
             timeLimit,
             dlimit: downloadLimit,
-            preferredPartSize: getPreferredPartSize(),
+            preferredPartSize,
         }),
     });
 
@@ -1151,9 +1189,6 @@ async function uploadMultipartStream(
     // Track actual uploaded part sizes for pre-completion consistency check
     const uploadedPartSizes: Record<number, number> = {};
 
-    // Track per-part start times for speed measurement
-    const partStartTimes: Record<number, number> = {};
-
     // Promise to signal when all uploads are done
     let resolveAllDone: () => void;
     const allDonePromise = new Promise<void>((resolve) => {
@@ -1170,7 +1205,6 @@ async function uploadMultipartStream(
             console.log(
                 `[Upload] Part ${partNum} starting (${(partBlob.size / (1024 * 1024)).toFixed(1)}MB)`,
             );
-            partStartTimes[partNum] = Date.now();
             const result = await uploadPartWithRetry(
                 partBlob,
                 partUrl,
@@ -1180,10 +1214,6 @@ async function uploadMultipartStream(
                 0,
                 onRetry,
             );
-            const elapsed = (Date.now() - partStartTimes[partNum]) / 1000;
-            if (elapsed > 0) {
-                updateObservedSpeed(partBlob.size / elapsed);
-            }
             completedParts.push(result);
             uploadedPartSizes[partNum] = partBlob.size;
             if (fileId) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1041,7 +1041,15 @@ export async function resumeUpload(
     }
 
     // Combine completed parts (contiguous prefix + newly uploaded)
-    const allParts = [...trulyCompletedParts, ...(multipartResult.parts || [])];
+    // Deduplicate by PartNumber, preferring newly uploaded ETags over persisted ones
+    const partMap = new Map<number, { PartNumber: number; ETag: string }>();
+    for (const p of trulyCompletedParts) {
+        partMap.set(p.PartNumber, p);
+    }
+    for (const p of multipartResult.parts || []) {
+        partMap.set(p.PartNumber, p);
+    }
+    const allParts = [...partMap.values()].sort((a, b) => a.PartNumber - b.PartNumber);
 
     // Complete the upload
     let metadataString: string;
@@ -1731,6 +1739,8 @@ function uploadPart(
             clearTimeout(stallTimer);
             stallTimer = setTimeout(() => {
                 stalledAbort = true;
+                window.removeEventListener('offline', handleOffline);
+                window.removeEventListener('online', handleOnline);
                 xhr.abort();
                 reject(new Error('Upload stalled'));
             }, STALL_TIMEOUT);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -813,7 +813,9 @@ export async function resumeUpload(
 
         const now = Date.now();
         const elapsed = (now - lastProgressTime) / 1000;
-        const bytesInPeriod = totalLoaded - lastProgressBytes - alreadyUploaded;
+        // Use partLoaded (not totalLoaded) for speed calculation to avoid
+        // the alreadyUploaded offset skewing the delta between updates
+        const bytesInPeriod = partLoaded - lastProgressBytes;
         const instantSpeed = elapsed > 0 ? Math.max(0, bytesInPeriod / elapsed) : 0;
 
         if (bytesInPeriod > 0) {
@@ -827,7 +829,7 @@ export async function resumeUpload(
             smoothedRemaining = smoothedSpeed > 0 ? (totalSize - totalLoaded) / smoothedSpeed : 0;
             lastDisplayTime = now;
             lastProgressTime = now;
-            lastProgressBytes = totalLoaded;
+            lastProgressBytes = partLoaded;
         }
 
         const isOffline = !navigator.onLine;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -59,6 +59,16 @@ function updateObservedSpeed(speed: number): void {
     }
 }
 
+function waitForOnline(): Promise<void> {
+    if (navigator.onLine) {
+        return Promise.resolve();
+    }
+    console.log('[Upload] Offline — waiting for connection...');
+    return new Promise((resolve) => {
+        window.addEventListener('online', () => resolve(), { once: true });
+    });
+}
+
 function getPreferredPartSize(): number | undefined {
     const speed = getObservedSpeed();
     if (speed === 0) {
@@ -1217,6 +1227,7 @@ async function uploadPartWithRetry(
         );
 
         if (retryCount < MAX_RETRIES && isRetryable) {
+            await waitForOnline();
             const delay = Math.min(
                 RETRY_DELAY_BASE * 2 ** retryCount + Math.random() * 1000,
                 MAX_RETRY_DELAY,
@@ -1279,6 +1290,16 @@ function uploadPart(
             }, STALL_TIMEOUT);
         };
 
+        // Pause stall timer when offline
+        const handleOffline = () => {
+            clearTimeout(stallTimer);
+        };
+        const handleOnline = () => {
+            resetStallTimer();
+        };
+        window.addEventListener('offline', handleOffline);
+        window.addEventListener('online', handleOnline);
+
         xhr.upload.addEventListener('progress', (e) => {
             resetStallTimer();
             if (e.lengthComputable) {
@@ -1290,6 +1311,8 @@ function uploadPart(
 
         xhr.addEventListener('loadend', () => {
             clearTimeout(stallTimer);
+            window.removeEventListener('offline', handleOffline);
+            window.removeEventListener('online', handleOnline);
             canceller.removeXhr(xhr);
 
             if (xhr.status >= 200 && xhr.status < 300) {
@@ -1321,6 +1344,8 @@ function uploadPart(
 
         xhr.addEventListener('error', () => {
             clearTimeout(stallTimer);
+            window.removeEventListener('offline', handleOffline);
+            window.removeEventListener('online', handleOnline);
             canceller.removeXhr(xhr);
             reject(new Error('Network error'));
         });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1878,10 +1878,13 @@ async function fetchWithRetry(url: string, options: RequestInit, retries = 3): P
 /**
  * Download a file
  */
+export type DownloadPhase = 'downloading' | 'decrypting' | 'finalizing';
+
 export async function downloadFile(
     id: string,
     keychain: Keychain | null,
     onProgress?: (loaded: number, total: number) => void,
+    onPhase?: (phase: DownloadPhase) => void,
 ): Promise<{ blob: Blob; filename: string }> {
     const dlStart = Date.now();
     const dlLog = (msg: string, data?: Record<string, unknown>) =>
@@ -2011,6 +2014,7 @@ export async function downloadFile(
         throw new Error('No response body');
     }
 
+    onPhase?.('downloading');
     dlLog('Starting download stream', {
         contentLength,
         metadataSize: metadata.size,
@@ -2077,6 +2081,7 @@ export async function downloadFile(
     // Decrypt if needed
     let decryptedData: Uint8Array;
     if (metadata.encrypted && keychain) {
+        onPhase?.('decrypting');
         dlLog('Starting decryption...', {
             encryptedSize: data.length,
             encryptedSizeMB: Math.round((data.length / (1024 * 1024)) * 10) / 10,
@@ -2112,6 +2117,7 @@ export async function downloadFile(
     }
 
     // Report download complete
+    onPhase?.('finalizing');
     dlLog('Reporting download complete to server...');
     await fetch(`${API_BASE_URL}/download/complete/${id}`, {
         method: 'POST',

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -34,6 +34,7 @@ export const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:30
 const MAX_RETRIES = 10;
 const RETRY_DELAY_BASE = 2000; // 2 seconds
 const MAX_RETRY_DELAY = 60000; // 60 seconds
+const STALL_TIMEOUT = 60_000; // Abort upload part if no progress for 60 seconds
 
 // Adaptive concurrency based on file size
 // With backpressure, memory is bounded to ~(concurrency + 1) * partSize
@@ -1223,13 +1224,26 @@ function uploadPart(
         const xhr = new XMLHttpRequest();
         canceller.addXhr(xhr);
 
+        let stallTimer: ReturnType<typeof setTimeout>;
+        const resetStallTimer = () => {
+            clearTimeout(stallTimer);
+            stallTimer = setTimeout(() => {
+                xhr.abort();
+                reject(new Error('Upload stalled'));
+            }, STALL_TIMEOUT);
+        };
+
         xhr.upload.addEventListener('progress', (e) => {
+            resetStallTimer();
             if (e.lengthComputable) {
                 onProgress(e.loaded);
             }
         });
 
+        xhr.addEventListener('loadstart', resetStallTimer);
+
         xhr.addEventListener('loadend', () => {
+            clearTimeout(stallTimer);
             canceller.removeXhr(xhr);
 
             if (xhr.status >= 200 && xhr.status < 300) {
@@ -1260,17 +1274,12 @@ function uploadPart(
         });
 
         xhr.addEventListener('error', () => {
+            clearTimeout(stallTimer);
             canceller.removeXhr(xhr);
             reject(new Error('Network error'));
         });
 
-        xhr.addEventListener('timeout', () => {
-            canceller.removeXhr(xhr);
-            reject(new Error('Timeout'));
-        });
-
         xhr.open('PUT', url);
-        xhr.timeout = 120000; // 2 minute timeout
         xhr.send(blob);
     });
 }
@@ -1287,6 +1296,7 @@ function isRetryableError(error: Error): boolean {
         msg.includes('network') ||
         msg.includes('timeout') ||
         msg.includes('abort') ||
+        msg.includes('stalled') ||
         msg.includes('failed to fetch') ||
         /http 5\d\d/.test(msg) ||
         msg.includes('http 429') ||

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -65,7 +65,14 @@ function waitForOnline(): Promise<void> {
  */
 async function measureUploadSpeed(): Promise<number> {
     try {
-        const blob = new Blob([crypto.getRandomValues(new Uint8Array(PREFLIGHT_SIZE))]);
+        // crypto.getRandomValues has a 65536-byte limit per call,
+        // so fill the buffer in chunks
+        const buffer = new Uint8Array(PREFLIGHT_SIZE);
+        for (let offset = 0; offset < PREFLIGHT_SIZE; offset += 65536) {
+            const chunk = Math.min(65536, PREFLIGHT_SIZE - offset);
+            crypto.getRandomValues(buffer.subarray(offset, offset + chunk));
+        }
+        const blob = new Blob([buffer]);
         let uploadedBytes = 0;
         const startTime = Date.now();
 
@@ -111,7 +118,8 @@ async function measureUploadSpeed(): Promise<number> {
             xhr.setRequestHeader('Content-Type', 'application/octet-stream');
             xhr.send(blob);
         });
-    } catch {
+    } catch (e) {
+        console.warn('[Upload] Speed test exception:', e);
         return 0;
     }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -87,17 +87,28 @@ async function measureUploadSpeed(): Promise<number> {
             xhr.addEventListener('loadend', () => {
                 clearTimeout(timeout);
                 const elapsed = (Date.now() - startTime) / 1000;
-                // Use total blob size on success, tracked bytes on abort
-                const bytes = xhr.status >= 200 && xhr.status < 300 ? blob.size : uploadedBytes;
-                resolve(elapsed > 0 ? bytes / elapsed : 0);
+                if (xhr.status >= 200 && xhr.status < 300) {
+                    resolve(elapsed > 0 ? blob.size / elapsed : 0);
+                } else if (xhr.status !== 0) {
+                    // Non-zero status = server responded with error
+                    console.warn(
+                        `[Upload] Speed test failed: HTTP ${xhr.status} ${xhr.statusText}`,
+                    );
+                    resolve(0);
+                } else {
+                    // status 0 = aborted by timeout (expected), use tracked bytes
+                    resolve(elapsed > 0 ? uploadedBytes / elapsed : 0);
+                }
             });
 
             xhr.addEventListener('error', () => {
                 clearTimeout(timeout);
+                console.warn(`[Upload] Speed test network error (status=${xhr.status})`);
                 resolve(0);
             });
 
-            xhr.open('PUT', `${API_BASE_URL}/upload/speedtest`);
+            xhr.open('POST', `${API_BASE_URL}/upload/speedtest`);
+            xhr.setRequestHeader('Content-Type', 'application/octet-stream');
             xhr.send(blob);
         });
     } catch {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -154,6 +154,7 @@ export interface UploadOptions {
     downloadLimit?: number;
     onProgress?: (progress: UploadProgress) => void;
     onZipProgress?: (percent: number) => void;
+    onSpeedTest?: (phase: 'started' | 'done', speedMbps?: number) => void;
     onError?: (error: UploadError) => void;
 }
 
@@ -425,6 +426,7 @@ export async function uploadFiles(
         downloadLimit,
         onProgress,
         onZipProgress,
+        onSpeedTest,
         onError,
     } = options;
 
@@ -515,14 +517,15 @@ export async function uploadFiles(
     }
 
     // Run preflight speed test to determine optimal part size
+    onSpeedTest?.('started');
     console.log('[Upload] Running preflight speed test...');
     const measuredSpeed = await measureUploadSpeed();
+    const speedMbps = Math.round((measuredSpeed / (1024 * 1024)) * 10) / 10;
     const preferredPartSize = getPreferredPartSize(measuredSpeed);
-    if (measuredSpeed > 0) {
-        console.log(
-            `[Upload] Preflight: ${(measuredSpeed / (1024 * 1024)).toFixed(1)} MB/s → ${preferredPartSize ? `${preferredPartSize / (1024 * 1024)}MB` : 'default'} parts`,
-        );
-    }
+    console.log(
+        `[Upload] Preflight result: ${speedMbps} MB/s → ${preferredPartSize ? `${preferredPartSize / (1024 * 1024)}MB` : 'default'} parts`,
+    );
+    onSpeedTest?.('done', speedMbps);
 
     // Request upload URLs
     const uploadResponse = await fetch(`${API_BASE_URL}/upload/url`, {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9,10 +9,17 @@ import {
     b64ToArray,
     calculateEncryptedSize,
     createEncryptionStream,
-    type Keychain,
+    ECE_RECORD_SIZE,
+    Keychain,
 } from './crypto';
 import { FileReadError } from './errors';
 import { addBreadcrumb, captureError } from './sentry';
+import {
+    deleteUploadState,
+    type PersistedUpload,
+    saveUploadState,
+    updateCompletedPart,
+} from './upload-state';
 import {
     createStreamingZip,
     createZipFromFiles,
@@ -561,6 +568,27 @@ export async function uploadFiles(
     let uploadResult: { actualSize: number; parts?: { PartNumber: number; ETag: string }[] };
 
     if (uploadInfo.multipart && uploadInfo.parts) {
+        // Persist upload state for resumability
+        const persistState: PersistedUpload = {
+            fileId: uploadInfo.id,
+            uploadId: uploadInfo.uploadId || '',
+            ownerToken: uploadInfo.owner,
+            fileName: files.length === 1 ? files[0].name : `${files.length}_files.zip`,
+            fileSize: totalSize,
+            fileLastModified: files.length === 1 ? files[0].lastModified : 0,
+            encrypted,
+            partSize: uploadInfo.partSize || 0,
+            completedParts: [],
+            totalParts: uploadInfo.parts.length,
+            secretKeyB64: encrypted ? keychain.secretKeyB64 : undefined,
+            timeLimit: timeLimit || 86400,
+            downloadLimit: downloadLimit || 1,
+            createdAt: Date.now(),
+        };
+        saveUploadState(persistState).catch((e) =>
+            console.warn('[Upload] Failed to persist upload state:', e),
+        );
+
         // Multipart upload
         const multipartResult = await uploadMultipartStream(
             stream,
@@ -576,6 +604,7 @@ export async function uploadFiles(
                 const part1Bytes = partProgress[1] ?? 0;
                 updateProgress(1, part1Bytes);
             },
+            uploadInfo.id,
         );
 
         // Handle fallback: stream produced too little data for multipart
@@ -636,6 +665,9 @@ export async function uploadFiles(
     if (canceller.cancelled) {
         if (uploadInfo.multipart && uploadInfo.uploadId) {
             await abortMultipartUpload(uploadInfo.id, uploadInfo.uploadId);
+            deleteUploadState(uploadInfo.id).catch(() => {
+                // Intentionally ignored — best-effort cleanup
+            });
         }
         throw new Error('Upload cancelled');
     }
@@ -676,6 +708,13 @@ export async function uploadFiles(
 
     const _completeInfo = await completeResponse.json();
 
+    // Clean up persisted upload state
+    if (uploadInfo.multipart) {
+        deleteUploadState(uploadInfo.id).catch(() => {
+            // Intentionally ignored — best-effort cleanup
+        });
+    }
+
     // Always use frontend origin for download URL (backend may return its own URL)
     // Don't include hash here - ShareDialog will append the secretKey
     const downloadUrl = `${window.location.origin}/download/${uploadInfo.id}`;
@@ -684,6 +723,220 @@ export async function uploadFiles(
         id: uploadInfo.id,
         url: downloadUrl,
         ownerToken: uploadInfo.owner,
+        duration: Date.now() - startTime,
+    };
+}
+
+/**
+ * Resume an interrupted multipart upload using persisted state from IndexedDB
+ */
+export async function resumeUpload(
+    file: File,
+    state: PersistedUpload,
+    onProgress?: (progress: UploadProgress) => void,
+    onError?: (error: UploadError) => void,
+    canceller?: Canceller,
+): Promise<UploadResult> {
+    const startTime = Date.now();
+    const cancel = canceller || new Canceller();
+
+    // Reconstruct keychain if encrypted
+    let keychain: Keychain | null = null;
+    if (state.encrypted && state.secretKeyB64) {
+        keychain = new Keychain(state.secretKeyB64);
+    }
+
+    // Determine which parts still need uploading
+    const completedPartNumbers = new Set(state.completedParts.map((p) => p.PartNumber));
+    const remainingPartNumbers: number[] = [];
+    for (let i = 1; i <= state.totalParts; i++) {
+        if (!completedPartNumbers.has(i)) {
+            remainingPartNumbers.push(i);
+        }
+    }
+
+    // Request new pre-signed URLs for remaining parts
+    const resumeResponse = await fetch(`${API_BASE_URL}/upload/multipart/${state.fileId}/resume`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            uploadId: state.uploadId,
+            completedPartNumbers: Array.from(completedPartNumbers),
+        }),
+    });
+
+    if (!resumeResponse.ok) {
+        // Upload expired or invalid — clean up and throw
+        await deleteUploadState(state.fileId);
+        throw new Error('Upload session expired. Please start a new upload.');
+    }
+
+    const resumeInfo: {
+        parts: Array<{ partNumber: number; url: string; minSize: number; maxSize: number }>;
+        partSize: number;
+        numParts: number;
+    } = await resumeResponse.json();
+
+    // Calculate how much data to skip (already uploaded)
+    const completedCount = state.completedParts.length;
+    const skipBytes = completedCount * state.partSize;
+
+    // Create a stream from the file, skipping already-uploaded data
+    const remainingBlob = file.slice(skipBytes);
+    let stream: ReadableStream<Uint8Array> = remainingBlob.stream();
+
+    // If encrypted, wrap with encryption stream starting at the correct counter
+    if (state.encrypted && keychain) {
+        const recordsPerPart = Math.ceil(state.partSize / ECE_RECORD_SIZE);
+        const initialCounter = completedCount * recordsPerPart;
+        stream = stream.pipeThrough(createEncryptionStream(keychain, initialCounter));
+    }
+
+    // Track progress
+    let smoothedSpeed = 0;
+    let smoothedRemaining = 0;
+    let lastProgressTime = startTime;
+    let lastProgressBytes = 0;
+    let lastDisplayTime = startTime;
+    let totalRetryCount = 0;
+    let lastPartProgressTime = Date.now();
+    const partProgress: Record<number, number> = {};
+
+    // Account for already-completed data in progress
+    const alreadyUploaded = skipBytes;
+    const totalSize = state.fileSize;
+
+    const updateProgress = (partNum: number, loaded: number) => {
+        partProgress[partNum] = loaded;
+        const partLoaded = Object.values(partProgress).reduce((sum, p) => sum + p, 0);
+        const totalLoaded = alreadyUploaded + partLoaded;
+
+        const now = Date.now();
+        const elapsed = (now - lastProgressTime) / 1000;
+        const bytesInPeriod = totalLoaded - lastProgressBytes - alreadyUploaded;
+        const instantSpeed = elapsed > 0 ? Math.max(0, bytesInPeriod / elapsed) : 0;
+
+        if (bytesInPeriod > 0) {
+            lastPartProgressTime = now;
+        }
+
+        const displayElapsed = (now - lastDisplayTime) / 1000;
+        if (displayElapsed >= 1 || lastDisplayTime === startTime) {
+            smoothedSpeed =
+                smoothedSpeed === 0 ? instantSpeed : smoothedSpeed * 0.7 + instantSpeed * 0.3;
+            smoothedRemaining = smoothedSpeed > 0 ? (totalSize - totalLoaded) / smoothedSpeed : 0;
+            lastDisplayTime = now;
+            lastProgressTime = now;
+            lastProgressBytes = totalLoaded;
+        }
+
+        const isOffline = !navigator.onLine;
+        let connectionQuality: UploadProgress['connectionQuality'];
+        if (isOffline) {
+            connectionQuality = 'offline';
+        } else if (smoothedSpeed === 0 || now - lastPartProgressTime > 10000) {
+            connectionQuality = 'stalled';
+        } else if (smoothedSpeed < 1 * 1024 * 1024) {
+            connectionQuality = 'slow';
+        } else if (smoothedSpeed < 10 * 1024 * 1024) {
+            connectionQuality = 'fair';
+        } else {
+            connectionQuality = 'good';
+        }
+
+        onProgress?.({
+            loaded: Math.min(totalLoaded, totalSize),
+            total: totalSize,
+            percentage: Math.min((totalLoaded / totalSize) * 100, 100),
+            speed: smoothedSpeed,
+            remainingTime: smoothedRemaining,
+            retryCount: totalRetryCount,
+            isOffline,
+            connectionQuality,
+        });
+    };
+
+    // Upload remaining parts using existing multipart machinery
+    const uploadInfoForResume: UploadUrlResponse = {
+        useSignedUrl: true,
+        multipart: true,
+        id: state.fileId,
+        owner: state.ownerToken,
+        uploadId: state.uploadId,
+        parts: resumeInfo.parts,
+        partSize: resumeInfo.partSize,
+        url: '',
+    };
+
+    const multipartResult = await uploadMultipartStream(
+        stream,
+        uploadInfoForResume,
+        updateProgress,
+        cancel,
+        onError,
+        totalSize,
+        () => {
+            totalRetryCount++;
+        },
+        state.fileId,
+    );
+
+    if ('fallbackBlob' in multipartResult) {
+        throw new Error('Resume failed: unexpected fallback');
+    }
+
+    if (cancel.cancelled) {
+        throw new Error('Upload cancelled');
+    }
+
+    // Combine completed parts (previously completed + newly completed)
+    const allParts = [...state.completedParts, ...(multipartResult.parts || [])];
+
+    // Complete the upload
+    let metadataString: string;
+    if (state.encrypted && keychain) {
+        const metadata = {
+            files: [
+                { name: file.name, size: file.size, type: file.type || 'application/octet-stream' },
+            ],
+        };
+        metadataString = arrayToB64(await keychain.encryptMetadata(metadata));
+    } else {
+        const metadata = {
+            files: [
+                { name: file.name, size: file.size, type: file.type || 'application/octet-stream' },
+            ],
+        };
+        metadataString = btoa(unescape(encodeURIComponent(JSON.stringify(metadata))));
+    }
+
+    const completeResponse = await fetchWithRetry(`${API_BASE_URL}/upload/complete`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            id: state.fileId,
+            metadata: metadataString,
+            ...(state.encrypted && keychain && { authKey: await keychain.authKeyB64() }),
+            actualSize: totalSize,
+            parts: allParts,
+        }),
+    });
+
+    if (!completeResponse.ok) {
+        throw new Error(`Failed to complete resumed upload: ${await completeResponse.text()}`);
+    }
+
+    await completeResponse.json();
+
+    // Clean up persisted state
+    await deleteUploadState(state.fileId);
+
+    const downloadUrl = `${window.location.origin}/download/${state.fileId}`;
+
+    return {
+        id: state.fileId,
+        url: downloadUrl,
+        ownerToken: state.ownerToken,
         duration: Date.now() - startTime,
     };
 }
@@ -830,6 +1083,7 @@ async function uploadMultipartStream(
     onError?: (error: UploadError) => void,
     totalFileSize?: number,
     onRetry?: () => void,
+    fileId?: string,
 ): Promise<MultipartStreamResult> {
     const { parts, partSize } = uploadInfo;
     if (!parts || !partSize) {
@@ -895,6 +1149,11 @@ async function uploadMultipartStream(
             }
             completedParts.push(result);
             uploadedPartSizes[partNum] = partBlob.size;
+            if (fileId) {
+                updateCompletedPart(fileId, result).catch((e) =>
+                    console.warn('[Upload] Failed to persist completed part:', e),
+                );
+            }
             console.log(`[Upload] Part ${partNum} complete`);
         } catch (error: unknown) {
             const message = error instanceof Error ? error.message : String(error);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -637,35 +637,38 @@ export async function uploadFiles(
 
     try {
         if (uploadInfo.multipart && uploadInfo.parts) {
-            // Persist upload state for resumability
-            // Store the raw (pre-encryption) file size for matching against File.size on resume
-            const rawFileSize = files.length === 1 ? files[0].size : totalInputSize;
-            // Calculate plaintext bytes per encrypted part
-            // Each ECE record: plaintext ECE_RECORD_SIZE → encrypted ECE_RECORD_SIZE + 17 (tag + delimiter)
-            const encryptedRecordSize = ECE_RECORD_SIZE + 17;
-            const plaintextPartSize = encrypted
-                ? Math.floor((uploadInfo.partSize || 0) / encryptedRecordSize) * ECE_RECORD_SIZE
-                : uploadInfo.partSize || 0;
-            const persistState: PersistedUpload = {
-                fileId: uploadInfo.id,
-                uploadId: uploadInfo.uploadId || '',
-                ownerToken: uploadInfo.owner,
-                fileName: files.length === 1 ? files[0].name : `${files.length}_files.zip`,
-                fileSize: rawFileSize,
-                fileLastModified: files.length === 1 ? files[0].lastModified : 0,
-                encrypted,
-                partSize: uploadInfo.partSize || 0,
-                plaintextPartSize,
-                completedParts: [],
-                totalParts: uploadInfo.parts.length,
-                secretKeyB64: encrypted ? keychain.secretKeyB64 : undefined,
-                timeLimit: timeLimit || 86400,
-                downloadLimit: downloadLimit || 1,
-                createdAt: Date.now(),
-            };
-            saveUploadState(persistState).catch((e) =>
-                console.warn('[Upload] Failed to persist upload state:', e),
-            );
+            // Only persist resumability state for single-file uploads.
+            // Multi-file uploads create a streaming zip that can't be
+            // reconstructed from the original files on resume.
+            const canResume = !isMultiFile;
+            if (canResume) {
+                // Calculate plaintext bytes per encrypted part
+                // Each ECE record: plaintext ECE_RECORD_SIZE → encrypted ECE_RECORD_SIZE + 17 (tag + delimiter)
+                const encryptedRecordSize = ECE_RECORD_SIZE + 17;
+                const plaintextPartSize = encrypted
+                    ? Math.floor((uploadInfo.partSize || 0) / encryptedRecordSize) * ECE_RECORD_SIZE
+                    : uploadInfo.partSize || 0;
+                const persistState: PersistedUpload = {
+                    fileId: uploadInfo.id,
+                    uploadId: uploadInfo.uploadId || '',
+                    ownerToken: uploadInfo.owner,
+                    fileName: files[0].name,
+                    fileSize: files[0].size,
+                    fileLastModified: files[0].lastModified,
+                    encrypted,
+                    partSize: uploadInfo.partSize || 0,
+                    plaintextPartSize,
+                    completedParts: [],
+                    totalParts: uploadInfo.parts.length,
+                    secretKeyB64: encrypted ? keychain.secretKeyB64 : undefined,
+                    timeLimit: timeLimit || 86400,
+                    downloadLimit: downloadLimit || 1,
+                    createdAt: Date.now(),
+                };
+                saveUploadState(persistState).catch((e) =>
+                    console.warn('[Upload] Failed to persist upload state:', e),
+                );
+            }
 
             // Multipart upload
             const multipartResult = await uploadMultipartStream(
@@ -682,7 +685,7 @@ export async function uploadFiles(
                     const part1Bytes = partProgress[1] ?? 0;
                     updateProgress(1, part1Bytes);
                 },
-                uploadInfo.id,
+                canResume ? uploadInfo.id : undefined,
             );
 
             // Handle fallback: stream produced too little data for multipart

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1883,13 +1883,28 @@ export async function downloadFile(
     keychain: Keychain | null,
     onProgress?: (loaded: number, total: number) => void,
 ): Promise<{ blob: Blob; filename: string }> {
+    const dlStart = Date.now();
+    const dlLog = (msg: string, data?: Record<string, unknown>) =>
+        console.log(`[Download] ${msg}`, data ? data : '');
+
+    dlLog('Starting', { fileId: id, encrypted: !!keychain });
     addBreadcrumb('downloadFile called', {
         category: 'download',
         data: { fileId: id, encrypted: !!keychain },
     });
 
     // Get metadata first
+    dlLog('Fetching metadata...');
+    const metaStart = Date.now();
     const metadata = await getMetadata(id, keychain || undefined);
+    dlLog('Metadata received', {
+        elapsed: Date.now() - metaStart,
+        name: metadata.name,
+        size: metadata.size,
+        encrypted: metadata.encrypted,
+        zipped: metadata.zipped,
+        fileCount: metadata.files?.length,
+    });
 
     // Get download URL
     const headers: Record<string, string> = {};
@@ -1933,6 +1948,11 @@ export async function downloadFile(
     }
 
     const urlData = await urlResponse.json();
+
+    dlLog('Got download URL', {
+        useSignedUrl: urlData.useSignedUrl,
+        urlLength: urlData.url?.length,
+    });
 
     // Download from signed URL or stream
     const downloadUrl = urlData.useSignedUrl ? urlData.url : `${API_BASE_URL}/download/${id}`;
@@ -1991,9 +2011,22 @@ export async function downloadFile(
         throw new Error('No response body');
     }
 
+    dlLog('Starting download stream', {
+        contentLength,
+        metadataSize: metadata.size,
+        responseHeaders: {
+            contentType: response.headers.get('Content-Type'),
+            contentLength: response.headers.get('Content-Length'),
+        },
+    });
+
     const chunks: Uint8Array[] = [];
     let loaded = 0;
+    let chunkCount = 0;
+    const streamStart = Date.now();
+    let lastLogTime = streamStart;
 
+    // biome-ignore lint/correctness/noConstantCondition: intentional stream drain loop
     while (true) {
         const { done, value } = await reader.read();
         if (done) {
@@ -2002,41 +2035,89 @@ export async function downloadFile(
 
         chunks.push(value);
         loaded += value.length;
+        chunkCount++;
         onProgress?.(loaded, contentLength || metadata.size || loaded);
+
+        // Log progress every 5 seconds
+        const now = Date.now();
+        if (now - lastLogTime > 5000) {
+            const elapsed = (now - streamStart) / 1000;
+            const speedMBps = loaded / (1024 * 1024) / elapsed;
+            dlLog('Download progress', {
+                loaded,
+                total: contentLength,
+                percentage: contentLength ? Math.round((loaded / contentLength) * 100) : '?',
+                chunks: chunkCount,
+                elapsed: `${elapsed.toFixed(1)}s`,
+                speed: `${speedMBps.toFixed(1)} MB/s`,
+            });
+            lastLogTime = now;
+        }
     }
 
+    const streamElapsed = Date.now() - streamStart;
+    dlLog('Download stream complete', {
+        totalBytes: loaded,
+        chunks: chunkCount,
+        elapsed: `${(streamElapsed / 1000).toFixed(1)}s`,
+        speed: `${(loaded / (1024 * 1024) / (streamElapsed / 1000)).toFixed(1)} MB/s`,
+    });
+
     // Combine chunks
+    dlLog('Combining chunks into buffer...', { chunks: chunks.length, totalBytes: loaded });
+    const combineStart = Date.now();
     const data = new Uint8Array(loaded);
     let offset = 0;
     for (const chunk of chunks) {
         data.set(chunk, offset);
         offset += chunk.length;
     }
+    dlLog('Buffer combined', { elapsed: Date.now() - combineStart });
 
     // Decrypt if needed
     let decryptedData: Uint8Array;
     if (metadata.encrypted && keychain) {
+        dlLog('Starting decryption...', {
+            encryptedSize: data.length,
+            encryptedSizeMB: Math.round((data.length / (1024 * 1024)) * 10) / 10,
+        });
+        const decryptStart = Date.now();
         const { createDecryptionStream } = await import('./crypto');
+        dlLog('Decryption stream created', { importElapsed: Date.now() - decryptStart });
+
         const decryptStream = createDecryptionStream(keychain);
         const decryptedResponse = new Response(
             new ReadableStream({
                 start(controller) {
+                    dlLog('Feeding encrypted data into decryption stream...');
                     controller.enqueue(data);
                     controller.close();
+                    dlLog('Encrypted data enqueued, stream closed');
                 },
             }).pipeThrough(decryptStream),
         );
+
+        dlLog('Awaiting decrypted arrayBuffer...');
         decryptedData = new Uint8Array(await decryptedResponse.arrayBuffer());
+        const decryptElapsed = Date.now() - decryptStart;
+        dlLog('Decryption complete', {
+            decryptedSize: decryptedData.length,
+            decryptedSizeMB: Math.round((decryptedData.length / (1024 * 1024)) * 10) / 10,
+            elapsed: `${(decryptElapsed / 1000).toFixed(1)}s`,
+            throughput: `${(decryptedData.length / (1024 * 1024) / (decryptElapsed / 1000)).toFixed(1)} MB/s`,
+        });
     } else {
+        dlLog('No decryption needed (unencrypted file)');
         decryptedData = data;
     }
 
     // Report download complete
+    dlLog('Reporting download complete to server...');
     await fetch(`${API_BASE_URL}/download/complete/${id}`, {
         method: 'POST',
         headers: keychain ? { Authorization: await keychain.authHeader() } : {},
     }).catch((e) => {
-        console.warn('Failed to report download complete:', e);
+        console.warn('[Download] Failed to report download complete:', e);
         captureError(e, {
             operation: 'download.complete',
             extra: { fileId: id },
@@ -2049,6 +2130,10 @@ export async function downloadFile(
 
     // If file was zipped at upload time, return the zip directly
     if (metadata.zipped) {
+        dlLog('Returning zipped file', {
+            filename: metadata.zipFilename,
+            size: decryptedData.length,
+        });
         return {
             blob: new Blob([decryptedData], { type: 'application/zip' }),
             filename: metadata.zipFilename || generateZipFilename(files || []),
@@ -2058,8 +2143,11 @@ export async function downloadFile(
     // Legacy: multiple files uploaded before zip-at-upload-time feature
     // Slice data and create zip on the fly (may fail for very large files)
     if (files && files.length > 1) {
+        dlLog('Creating zip from legacy multi-file download', { fileCount: files.length });
+        const zipStart = Date.now();
         const fileSlices = sliceConcatenatedData(decryptedData, files);
         const zipBlob = await createZipFromFiles(fileSlices);
+        dlLog('Legacy zip created', { elapsed: Date.now() - zipStart, zipSize: zipBlob.size });
         return {
             blob: zipBlob,
             filename: generateZipFilename(files),
@@ -2067,6 +2155,13 @@ export async function downloadFile(
     }
 
     // Single file: return as-is
+    const totalElapsed = Date.now() - dlStart;
+    dlLog('Download complete', {
+        filename: metadata.name,
+        size: decryptedData.length,
+        sizeMB: Math.round((decryptedData.length / (1024 * 1024)) * 10) / 10,
+        totalElapsed: `${(totalElapsed / 1000).toFixed(1)}s`,
+    });
     return {
         blob: new Blob([decryptedData]),
         filename: metadata.name || 'download',

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -569,15 +569,24 @@ export async function uploadFiles(
 
     if (uploadInfo.multipart && uploadInfo.parts) {
         // Persist upload state for resumability
+        // Store the raw (pre-encryption) file size for matching against File.size on resume
+        const rawFileSize = files.length === 1 ? files[0].size : totalInputSize;
+        // Calculate plaintext bytes per encrypted part
+        // Each ECE record: plaintext ECE_RECORD_SIZE → encrypted ECE_RECORD_SIZE + 17 (tag + delimiter)
+        const encryptedRecordSize = ECE_RECORD_SIZE + 17;
+        const plaintextPartSize = encrypted
+            ? Math.floor((uploadInfo.partSize || 0) / encryptedRecordSize) * ECE_RECORD_SIZE
+            : uploadInfo.partSize || 0;
         const persistState: PersistedUpload = {
             fileId: uploadInfo.id,
             uploadId: uploadInfo.uploadId || '',
             ownerToken: uploadInfo.owner,
             fileName: files.length === 1 ? files[0].name : `${files.length}_files.zip`,
-            fileSize: totalSize,
+            fileSize: rawFileSize,
             fileLastModified: files.length === 1 ? files[0].lastModified : 0,
             encrypted,
             partSize: uploadInfo.partSize || 0,
+            plaintextPartSize,
             completedParts: [],
             totalParts: uploadInfo.parts.length,
             secretKeyB64: encrypted ? keychain.secretKeyB64 : undefined,
@@ -746,14 +755,22 @@ export async function resumeUpload(
         keychain = new Keychain(state.secretKeyB64);
     }
 
-    // Determine which parts still need uploading
-    const completedPartNumbers = new Set(state.completedParts.map((p) => p.PartNumber));
-    const remainingPartNumbers: number[] = [];
-    for (let i = 1; i <= state.totalParts; i++) {
-        if (!completedPartNumbers.has(i)) {
-            remainingPartNumbers.push(i);
+    // Find contiguous prefix of completed parts (concurrent uploads may leave gaps)
+    // Only the contiguous prefix can be safely skipped — parts after a gap need re-uploading
+    const sortedCompleted = [...state.completedParts].sort((a, b) => a.PartNumber - b.PartNumber);
+    let contiguousCount = 0;
+    for (const p of sortedCompleted) {
+        if (p.PartNumber === contiguousCount + 1) {
+            contiguousCount++;
+        } else {
+            break;
         }
     }
+    const trulyCompletedParts = sortedCompleted.slice(0, contiguousCount);
+
+    // Use plaintext part size for file offset (encrypted part size includes ECE overhead)
+    const plaintextPartSize = state.plaintextPartSize || state.partSize;
+    const skipBytes = contiguousCount * plaintextPartSize;
 
     // Request new pre-signed URLs for remaining parts
     const resumeResponse = await fetch(`${API_BASE_URL}/upload/multipart/${state.fileId}/resume`, {
@@ -761,7 +778,7 @@ export async function resumeUpload(
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
             uploadId: state.uploadId,
-            completedPartNumbers: Array.from(completedPartNumbers),
+            completedPartNumbers: trulyCompletedParts.map((p) => p.PartNumber),
         }),
     });
 
@@ -777,18 +794,15 @@ export async function resumeUpload(
         numParts: number;
     } = await resumeResponse.json();
 
-    // Calculate how much data to skip (already uploaded)
-    const completedCount = state.completedParts.length;
-    const skipBytes = completedCount * state.partSize;
-
     // Create a stream from the file, skipping already-uploaded data
     const remainingBlob = file.slice(skipBytes);
     let stream: ReadableStream<Uint8Array> = remainingBlob.stream();
 
     // If encrypted, wrap with encryption stream starting at the correct counter
     if (state.encrypted && keychain) {
-        const recordsPerPart = Math.ceil(state.partSize / ECE_RECORD_SIZE);
-        const initialCounter = completedCount * recordsPerPart;
+        // Each plaintext part contains ceil(plaintextPartSize / ECE_RECORD_SIZE) records
+        const recordsPerPart = Math.ceil(plaintextPartSize / ECE_RECORD_SIZE);
+        const initialCounter = contiguousCount * recordsPerPart;
         stream = stream.pipeThrough(createEncryptionStream(keychain, initialCounter));
     }
 
@@ -803,8 +817,9 @@ export async function resumeUpload(
     const partProgress: Record<number, number> = {};
 
     // Account for already-completed data in progress
-    const alreadyUploaded = skipBytes;
-    const totalSize = state.fileSize;
+    // Use encrypted part size for progress since that's what's actually uploaded
+    const alreadyUploaded = contiguousCount * state.partSize;
+    const totalSize = state.totalParts * state.partSize;
 
     const updateProgress = (partNum: number, loaded: number) => {
         partProgress[partNum] = loaded;
@@ -891,8 +906,8 @@ export async function resumeUpload(
         throw new Error('Upload cancelled');
     }
 
-    // Combine completed parts (previously completed + newly completed)
-    const allParts = [...state.completedParts, ...(multipartResult.parts || [])];
+    // Combine completed parts (contiguous prefix + newly uploaded)
+    const allParts = [...trulyCompletedParts, ...(multipartResult.parts || [])];
 
     // Complete the upload
     let metadataString: string;
@@ -1585,9 +1600,11 @@ function uploadPart(
         canceller.addXhr(xhr);
 
         let stallTimer: ReturnType<typeof setTimeout>;
+        let stalledAbort = false;
         const resetStallTimer = () => {
             clearTimeout(stallTimer);
             stallTimer = setTimeout(() => {
+                stalledAbort = true;
                 xhr.abort();
                 reject(new Error('Upload stalled'));
             }, STALL_TIMEOUT);
@@ -1621,7 +1638,9 @@ function uploadPart(
             if (xhr.status >= 200 && xhr.status < 300) {
                 const etag = xhr.getResponseHeader('ETag') || '';
                 resolve({ PartNumber: partNumber, ETag: etag });
-            } else {
+            } else if (!stalledAbort) {
+                // Skip error reporting if this was an intentional stall abort
+                // (the stall timer already rejected with 'Upload stalled')
                 let errorDetails = `HTTP ${xhr.status}`;
                 if (xhr.statusText) {
                     errorDetails += ` (${xhr.statusText})`;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -45,7 +45,6 @@ const STALL_TIMEOUT = 60_000; // Abort upload part if no progress for 60 seconds
 
 // Preflight speed test configuration
 const SPEEDTEST_PART_SIZE = 100 * 1024 * 1024; // 100MB per part
-const SPEEDTEST_PARTS = 5; // 5 concurrent parts
 const SPEEDTEST_TIMEOUT = 10_000; // Run for up to 10 seconds
 
 function waitForOnline(): Promise<void> {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -44,7 +44,7 @@ const MAX_RETRY_DELAY = 60000; // 60 seconds
 const STALL_TIMEOUT = 60_000; // Abort upload part if no progress for 60 seconds
 
 // Preflight speed test configuration
-const PREFLIGHT_SIZE = 20 * 1024 * 1024; // 20MB test payload
+const PREFLIGHT_SIZE = 500 * 1024 * 1024; // 500MB test payload
 const PREFLIGHT_TIMEOUT = 10_000; // Run for up to 10 seconds
 
 function waitForOnline(): Promise<void> {
@@ -65,14 +65,9 @@ function waitForOnline(): Promise<void> {
  */
 async function measureUploadSpeed(): Promise<number> {
     try {
-        // crypto.getRandomValues has a 65536-byte limit per call,
-        // so fill the buffer in chunks
-        const buffer = new Uint8Array(PREFLIGHT_SIZE);
-        for (let offset = 0; offset < PREFLIGHT_SIZE; offset += 65536) {
-            const chunk = Math.min(65536, PREFLIGHT_SIZE - offset);
-            crypto.getRandomValues(buffer.subarray(offset, offset + chunk));
-        }
-        const blob = new Blob([buffer]);
+        // Create a zero-filled blob — content doesn't matter for speed measurement,
+        // and this avoids the cost of filling 500MB with random data
+        const blob = new Blob([new ArrayBuffer(PREFLIGHT_SIZE)]);
         let uploadedBytes = 0;
         const startTime = Date.now();
 
@@ -816,6 +811,13 @@ export async function uploadFiles(
         };
     } finally {
         cleanupStatusPoll();
+        // If cancelled, always clean up persisted state — the user
+        // intentionally cancelled, so don't offer resume on next visit
+        if (canceller.cancelled && uploadInfo.multipart) {
+            deleteUploadState(uploadInfo.id).catch(() => {
+                // Intentionally ignored — best-effort cleanup
+            });
+        }
     }
 }
 

--- a/frontend/src/lib/crypto.ts
+++ b/frontend/src/lib/crypto.ts
@@ -236,8 +236,9 @@ export class Keychain {
  */
 export function createEncryptionStream(
     keychain: Keychain,
+    initialCounter = 0,
 ): TransformStream<Uint8Array, Uint8Array> {
-    let recordCount = 0;
+    let recordCount = initialCounter;
     let buffer = new Uint8Array(0);
     let encryptionKey: CryptoKey;
 

--- a/frontend/src/lib/upload-state.ts
+++ b/frontend/src/lib/upload-state.ts
@@ -107,8 +107,10 @@ export async function getResumableUpload(
                     state.fileSize === fileSize &&
                     state.fileLastModified === lastModified
                 ) {
-                    found = state;
-                    return; // Stop scanning after first match
+                    // Keep the most recent match (by createdAt)
+                    if (!found || state.createdAt > found.createdAt) {
+                        found = state;
+                    }
                 }
                 cursor.continue();
             }

--- a/frontend/src/lib/upload-state.ts
+++ b/frontend/src/lib/upload-state.ts
@@ -124,6 +124,31 @@ export async function getResumableUpload(
     });
 }
 
+export async function getAnyResumableUpload(): Promise<PersistedUpload | null> {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readonly');
+        const store = tx.objectStore(STORE_NAME);
+        const request = store.openCursor();
+
+        request.onsuccess = () => {
+            const cursor = request.result;
+            if (cursor) {
+                resolve(cursor.value as PersistedUpload);
+                return; // Return first found
+            }
+            resolve(null);
+        };
+        tx.oncomplete = () => {
+            db.close();
+        };
+        tx.onerror = () => {
+            db.close();
+            reject(tx.error);
+        };
+    });
+}
+
 export async function deleteUploadState(fileId: string): Promise<void> {
     const db = await openDB();
     return new Promise((resolve, reject) => {

--- a/frontend/src/lib/upload-state.ts
+++ b/frontend/src/lib/upload-state.ts
@@ -1,0 +1,169 @@
+/**
+ * IndexedDB persistence for multipart upload state.
+ * Allows uploads to survive page reloads.
+ */
+
+export interface PersistedUpload {
+    fileId: string; // Bolter file ID
+    uploadId: string; // S3 multipart upload ID
+    ownerToken: string; // For completion/abort
+    fileName: string; // To match against re-selected file
+    fileSize: number; // To verify same file
+    fileLastModified: number; // To verify same file
+    encrypted: boolean;
+    partSize: number; // Part size used
+    completedParts: Array<{ PartNumber: number; ETag: string }>;
+    totalParts: number;
+    encryptionSalt?: string; // Base64 salt for key derivation (reserved)
+    secretKeyB64?: string; // Base64 secret key (to reconstruct Keychain)
+    timeLimit: number;
+    downloadLimit: number;
+    createdAt: number; // Timestamp for cleanup
+}
+
+const DB_NAME = 'bolter-uploads';
+const DB_VERSION = 1;
+const STORE_NAME = 'uploads';
+
+function openDB(): Promise<IDBDatabase> {
+    return new Promise((resolve, reject) => {
+        const request = indexedDB.open(DB_NAME, DB_VERSION);
+        request.onupgradeneeded = () => {
+            const db = request.result;
+            if (!db.objectStoreNames.contains(STORE_NAME)) {
+                db.createObjectStore(STORE_NAME, { keyPath: 'fileId' });
+            }
+        };
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+    });
+}
+
+export async function saveUploadState(state: PersistedUpload): Promise<void> {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readwrite');
+        tx.objectStore(STORE_NAME).put(state);
+        tx.oncomplete = () => {
+            db.close();
+            resolve();
+        };
+        tx.onerror = () => {
+            db.close();
+            reject(tx.error);
+        };
+    });
+}
+
+export async function updateCompletedPart(
+    fileId: string,
+    part: { PartNumber: number; ETag: string },
+): Promise<void> {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readwrite');
+        const store = tx.objectStore(STORE_NAME);
+        const getReq = store.get(fileId);
+        getReq.onsuccess = () => {
+            const state = getReq.result as PersistedUpload | undefined;
+            if (state) {
+                // Avoid duplicates
+                if (!state.completedParts.some((p) => p.PartNumber === part.PartNumber)) {
+                    state.completedParts.push(part);
+                    store.put(state);
+                }
+            }
+        };
+        tx.oncomplete = () => {
+            db.close();
+            resolve();
+        };
+        tx.onerror = () => {
+            db.close();
+            reject(tx.error);
+        };
+    });
+}
+
+export async function getResumableUpload(
+    fileName: string,
+    fileSize: number,
+    lastModified: number,
+): Promise<PersistedUpload | null> {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readonly');
+        const store = tx.objectStore(STORE_NAME);
+        const request = store.openCursor();
+        let found: PersistedUpload | null = null;
+
+        request.onsuccess = () => {
+            const cursor = request.result;
+            if (cursor) {
+                const state = cursor.value as PersistedUpload;
+                if (
+                    state.fileName === fileName &&
+                    state.fileSize === fileSize &&
+                    state.fileLastModified === lastModified
+                ) {
+                    found = state;
+                }
+                cursor.continue();
+            }
+        };
+        tx.oncomplete = () => {
+            db.close();
+            resolve(found);
+        };
+        tx.onerror = () => {
+            db.close();
+            reject(tx.error);
+        };
+    });
+}
+
+export async function deleteUploadState(fileId: string): Promise<void> {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readwrite');
+        tx.objectStore(STORE_NAME).delete(fileId);
+        tx.oncomplete = () => {
+            db.close();
+            resolve();
+        };
+        tx.onerror = () => {
+            db.close();
+            reject(tx.error);
+        };
+    });
+}
+
+export async function cleanupExpiredUploads(): Promise<void> {
+    const SEVEN_DAYS = 7 * 24 * 60 * 60 * 1000;
+    const cutoff = Date.now() - SEVEN_DAYS;
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readwrite');
+        const store = tx.objectStore(STORE_NAME);
+        const request = store.openCursor();
+
+        request.onsuccess = () => {
+            const cursor = request.result;
+            if (cursor) {
+                const state = cursor.value as PersistedUpload;
+                if (state.createdAt < cutoff) {
+                    cursor.delete();
+                }
+                cursor.continue();
+            }
+        };
+        tx.oncomplete = () => {
+            db.close();
+            resolve();
+        };
+        tx.onerror = () => {
+            db.close();
+            reject(tx.error);
+        };
+    });
+}

--- a/frontend/src/lib/upload-state.ts
+++ b/frontend/src/lib/upload-state.ts
@@ -8,10 +8,11 @@ export interface PersistedUpload {
     uploadId: string; // S3 multipart upload ID
     ownerToken: string; // For completion/abort
     fileName: string; // To match against re-selected file
-    fileSize: number; // To verify same file
+    fileSize: number; // Raw (pre-encryption) file size for matching
     fileLastModified: number; // To verify same file
     encrypted: boolean;
-    partSize: number; // Part size used
+    partSize: number; // Encrypted part size used by S3
+    plaintextPartSize: number; // Plaintext bytes per part (for resume offset)
     completedParts: Array<{ PartNumber: number; ETag: string }>;
     totalParts: number;
     encryptionSalt?: string; // Base64 salt for key derivation (reserved)
@@ -107,6 +108,7 @@ export async function getResumableUpload(
                     state.fileLastModified === lastModified
                 ) {
                     found = state;
+                    return; // Stop scanning after first match
                 }
                 cursor.continue();
             }

--- a/frontend/src/pages/Download.tsx
+++ b/frontend/src/pages/Download.tsx
@@ -16,6 +16,7 @@ import { useDocumentMeta } from '@/hooks/useDocumentMeta';
 import {
     API_BASE_URL,
     checkLegacyFile,
+    type DownloadPhase,
     downloadFile,
     fileExists,
     getDownloadStatus,
@@ -51,6 +52,7 @@ export function DownloadPage() {
     const [keychain, setKeychain] = useState<Keychain | null>(null);
     const [canDownloadAgain, setCanDownloadAgain] = useState(true);
     const [downloadsLeft, setDownloadsLeft] = useState<number | null>(null);
+    const [downloadPhase, setDownloadPhase] = useState<DownloadPhase>('downloading');
     const loadingRef = useRef(false);
 
     // Compute document meta based on state and metadata
@@ -205,11 +207,19 @@ export function DownloadPage() {
         });
         setState('downloading');
         setProgress(0);
+        setDownloadPhase('downloading');
 
         try {
-            const result = await downloadFile(id, keychain, (loaded, total) => {
-                setProgress((loaded / total) * 100);
-            });
+            const result = await downloadFile(
+                id,
+                keychain,
+                (loaded, total) => {
+                    setProgress((loaded / total) * 100);
+                },
+                (phase) => {
+                    setDownloadPhase(phase);
+                },
+            );
 
             // Trigger browser download
             triggerDownload(result.blob, result.filename);
@@ -465,10 +475,16 @@ export function DownloadPage() {
                         {/* Download button or progress */}
                         {state === 'downloading' ? (
                             <div className="w-full space-y-3">
-                                <Progress value={progress} className="h-2" />
+                                <Progress
+                                    value={downloadPhase === 'downloading' ? progress : 100}
+                                    className="h-2"
+                                />
                                 <p className="text-center text-paragraph-xs text-content-secondary">
-                                    Downloading{metadata?.encrypted ? ' and decrypting' : ''}...{' '}
-                                    {Math.round(progress)}%
+                                    {downloadPhase === 'decrypting'
+                                        ? 'Decrypting...'
+                                        : downloadPhase === 'finalizing'
+                                          ? 'Finalizing...'
+                                          : `Downloading... ${Math.round(progress)}%`}
                                 </p>
                             </div>
                         ) : (

--- a/frontend/src/pages/Download.tsx
+++ b/frontend/src/pages/Download.tsx
@@ -126,8 +126,9 @@ export function DownloadPage() {
                     setDownloadsLeft(status.dlimit - status.dl);
                 }
 
-                // Create keychain if we have a secret key
-                const kc = secretKey ? new Keychain(secretKey) : null;
+                // Create keychain if we have a secret key and crypto.subtle is available
+                // (crypto.subtle requires a secure context: HTTPS or localhost)
+                const kc = secretKey && crypto?.subtle ? new Keychain(secretKey) : null;
                 setKeychain(kc);
 
                 // Fetch metadata

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import { UPLOAD_LIMITS } from '@bolter/shared';
-import { ChevronDown, ChevronUp, Plus } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
+import { ChevronDown, ChevronUp, Plus, Upload } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { DropZone } from '@/components/DropZone';
 import { FileList } from '@/components/FileList';
@@ -13,7 +13,11 @@ import { Canceller, FileReadError, resumeUpload, uploadFiles } from '@/lib/api';
 import { Keychain } from '@/lib/crypto';
 import { trackUpload } from '@/lib/plausible';
 import { addBreadcrumb, captureError } from '@/lib/sentry';
-import { cleanupExpiredUploads, deleteUploadState, getResumableUpload } from '@/lib/upload-state';
+import {
+    cleanupExpiredUploads,
+    deleteUploadState,
+    getAnyResumableUpload,
+} from '@/lib/upload-state';
 import { formatBytes } from '@/lib/utils';
 import { type UploadedFile, useAppStore } from '@/stores/app';
 
@@ -43,96 +47,106 @@ export function HomePage() {
         setResumableUpload,
     } = useAppStore();
 
-    // Check for resumable uploads when files change
+    const resumeFileInputRef = useRef<HTMLInputElement>(null);
+
+    // Check for any resumable upload on mount
     useEffect(() => {
-        if (files.length === 1) {
-            const file = files[0].file;
-            cleanupExpiredUploads()
-                .then(() => getResumableUpload(file.name, file.size, file.lastModified))
-                .then((state) => setResumableUpload(state))
-                .catch(() => setResumableUpload(null));
-        } else {
-            setResumableUpload(null);
-        }
-    }, [files, setResumableUpload]);
+        cleanupExpiredUploads()
+            .then(() => getAnyResumableUpload())
+            .then((state) => setResumableUpload(state))
+            .catch(() => setResumableUpload(null));
+    }, [setResumableUpload]);
 
-    const handleResume = useCallback(async () => {
-        if (!resumableUpload || files.length !== 1) {
-            return;
-        }
+    const handleResumeFileSelected = useCallback(
+        async (file: File) => {
+            if (!resumableUpload) {
+                return;
+            }
 
-        const file = files[0].file;
-        const canceller = new Canceller();
-        const keychain =
-            resumableUpload.encrypted && resumableUpload.secretKeyB64
-                ? new Keychain(resumableUpload.secretKeyB64)
-                : new Keychain();
-
-        setUploading(true);
-        setUploadError(null);
-        setCanceller(canceller);
-        setKeychain(keychain);
-
-        try {
-            const result = await resumeUpload(
-                file,
-                resumableUpload,
-                (progress) => setUploadProgress(progress),
-                (error) => console.error('Resume error:', error),
-                canceller,
-            );
-
-            const uploaded: UploadedFile = {
-                id: result.id,
-                url: result.url,
-                secretKey: keychain.secretKeyB64,
-                ownerToken: result.ownerToken,
-                name: file.name,
-                size: file.size,
-                expiresAt: new Date(Date.now() + resumableUpload.timeLimit * 1000),
-                downloadLimit: resumableUpload.downloadLimit,
-                downloadCount: 0,
-            };
-
-            addUploadedFile(uploaded);
-            setUploadedFile(uploaded);
-            clearFiles();
-            setResumableUpload(null);
-
-            addToast({
-                title: 'Upload resumed and completed!',
-                description: 'Your file is ready to share.',
-                variant: 'success',
-            });
-        } catch (e: unknown) {
-            const message = e instanceof Error ? e.message : String(e);
-            if (message !== 'Upload cancelled') {
-                setUploadError(message);
+            // Verify the file matches
+            if (
+                file.name !== resumableUpload.fileName ||
+                file.size !== resumableUpload.fileSize ||
+                file.lastModified !== resumableUpload.fileLastModified
+            ) {
                 addToast({
-                    title: 'Resume failed',
-                    description: message,
+                    title: 'Wrong file',
+                    description: `Please select "${resumableUpload.fileName}" to resume the upload.`,
                     variant: 'destructive',
                 });
+                return;
             }
-        } finally {
-            setUploading(false);
-            setUploadProgress(null);
-            setCanceller(null);
-            setKeychain(null);
-        }
-    }, [
-        resumableUpload,
-        files,
-        setUploading,
-        setUploadError,
-        setCanceller,
-        setKeychain,
-        setUploadProgress,
-        addUploadedFile,
-        clearFiles,
-        addToast,
-        setResumableUpload,
-    ]);
+
+            const canceller = new Canceller();
+            const keychain =
+                resumableUpload.encrypted && resumableUpload.secretKeyB64
+                    ? new Keychain(resumableUpload.secretKeyB64)
+                    : new Keychain();
+
+            setUploading(true);
+            setUploadError(null);
+            setCanceller(canceller);
+            setKeychain(keychain);
+
+            try {
+                const result = await resumeUpload(
+                    file,
+                    resumableUpload,
+                    (progress) => setUploadProgress(progress),
+                    (error) => console.error('Resume error:', error),
+                    canceller,
+                );
+
+                const uploaded: UploadedFile = {
+                    id: result.id,
+                    url: result.url,
+                    secretKey: keychain.secretKeyB64,
+                    ownerToken: result.ownerToken,
+                    name: file.name,
+                    size: file.size,
+                    expiresAt: new Date(Date.now() + resumableUpload.timeLimit * 1000),
+                    downloadLimit: resumableUpload.downloadLimit,
+                    downloadCount: 0,
+                };
+
+                addUploadedFile(uploaded);
+                setUploadedFile(uploaded);
+                setResumableUpload(null);
+
+                addToast({
+                    title: 'Upload resumed and completed!',
+                    description: 'Your file is ready to share.',
+                    variant: 'success',
+                });
+            } catch (e: unknown) {
+                const message = e instanceof Error ? e.message : String(e);
+                if (message !== 'Upload cancelled') {
+                    setUploadError(message);
+                    addToast({
+                        title: 'Resume failed',
+                        description: message,
+                        variant: 'destructive',
+                    });
+                }
+            } finally {
+                setUploading(false);
+                setUploadProgress(null);
+                setCanceller(null);
+                setKeychain(null);
+            }
+        },
+        [
+            resumableUpload,
+            setUploading,
+            setUploadError,
+            setCanceller,
+            setKeychain,
+            setUploadProgress,
+            addUploadedFile,
+            addToast,
+            setResumableUpload,
+        ],
+    );
 
     const handleStartFresh = useCallback(() => {
         if (resumableUpload) {
@@ -301,7 +315,49 @@ export function HomePage() {
                 {/* Main Card */}
                 <div className="card-glass p-card shadow-card">
                     <div className="relative z-10 flex flex-col gap-5">
-                        {!isUploading && (
+                        {!isUploading && resumableUpload && (
+                            <div className="bg-overlay-subtle border border-border-medium rounded-element p-6 flex flex-col items-center gap-4 text-center">
+                                <Upload className="h-8 w-8 text-content-secondary" />
+                                <div>
+                                    <p className="text-paragraph-sm font-medium text-content-primary mb-1">
+                                        Resume interrupted upload
+                                    </p>
+                                    <p className="text-paragraph-xs text-content-secondary">
+                                        <span className="font-medium">
+                                            {resumableUpload.fileName}
+                                        </span>{' '}
+                                        ({formatBytes(resumableUpload.fileSize)}) &mdash;{' '}
+                                        {resumableUpload.completedParts.length} of{' '}
+                                        {resumableUpload.totalParts} parts completed
+                                    </p>
+                                </div>
+                                <div className="flex gap-3 w-full">
+                                    <Button
+                                        className="flex-1"
+                                        onClick={() => resumeFileInputRef.current?.click()}
+                                    >
+                                        Select file to resume
+                                    </Button>
+                                    <Button variant="ghost" onClick={handleStartFresh}>
+                                        Start fresh
+                                    </Button>
+                                </div>
+                                <input
+                                    ref={resumeFileInputRef}
+                                    type="file"
+                                    className="hidden"
+                                    onChange={(e) => {
+                                        const file = e.target.files?.[0];
+                                        if (file) {
+                                            handleResumeFileSelected(file);
+                                        }
+                                        e.target.value = '';
+                                    }}
+                                />
+                            </div>
+                        )}
+
+                        {!isUploading && !resumableUpload && (
                             <>
                                 <DropZone />
 
@@ -385,31 +441,6 @@ export function HomePage() {
                                                 <UploadSettings />
                                             </div>
                                         )}
-                                    </div>
-                                )}
-
-                                {resumableUpload && !isUploading && (
-                                    <div className="bg-overlay-subtle border border-border-medium rounded-element p-4">
-                                        <p className="text-paragraph-sm font-medium text-content-primary mb-1">
-                                            Resume previous upload?
-                                        </p>
-                                        <p className="text-paragraph-xs text-content-secondary mb-3">
-                                            A previous upload of this file was interrupted.{' '}
-                                            {resumableUpload.completedParts.length} of{' '}
-                                            {resumableUpload.totalParts} parts completed.
-                                        </p>
-                                        <div className="flex gap-2">
-                                            <Button size="sm" onClick={handleResume}>
-                                                Resume
-                                            </Button>
-                                            <Button
-                                                size="sm"
-                                                variant="ghost"
-                                                onClick={handleStartFresh}
-                                            >
-                                                Start fresh
-                                            </Button>
-                                        </div>
                                     </div>
                                 )}
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import { UPLOAD_LIMITS } from '@bolter/shared';
 import { ChevronDown, ChevronUp, Plus } from 'lucide-react';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { DropZone } from '@/components/DropZone';
 import { FileList } from '@/components/FileList';
@@ -9,10 +9,11 @@ import { UploadedFilesList } from '@/components/UploadedFilesList';
 import { UploadProgress } from '@/components/UploadProgress';
 import { UploadSettings } from '@/components/UploadSettings';
 import { Button } from '@/components/ui/button';
-import { Canceller, FileReadError, uploadFiles } from '@/lib/api';
+import { Canceller, FileReadError, resumeUpload, uploadFiles } from '@/lib/api';
 import { Keychain } from '@/lib/crypto';
 import { trackUpload } from '@/lib/plausible';
 import { addBreadcrumb, captureError } from '@/lib/sentry';
+import { cleanupExpiredUploads, deleteUploadState, getResumableUpload } from '@/lib/upload-state';
 import { formatBytes } from '@/lib/utils';
 import { type UploadedFile, useAppStore } from '@/stores/app';
 
@@ -38,7 +39,109 @@ export function HomePage() {
         addUploadedFile,
         addToast,
         config,
+        resumableUpload,
+        setResumableUpload,
     } = useAppStore();
+
+    // Check for resumable uploads when files change
+    useEffect(() => {
+        if (files.length === 1) {
+            const file = files[0].file;
+            cleanupExpiredUploads()
+                .then(() => getResumableUpload(file.name, file.size, file.lastModified))
+                .then((state) => setResumableUpload(state))
+                .catch(() => setResumableUpload(null));
+        } else {
+            setResumableUpload(null);
+        }
+    }, [files, setResumableUpload]);
+
+    const handleResume = useCallback(async () => {
+        if (!resumableUpload || files.length !== 1) {
+            return;
+        }
+
+        const file = files[0].file;
+        const canceller = new Canceller();
+        const keychain =
+            resumableUpload.encrypted && resumableUpload.secretKeyB64
+                ? new Keychain(resumableUpload.secretKeyB64)
+                : new Keychain();
+
+        setUploading(true);
+        setUploadError(null);
+        setCanceller(canceller);
+        setKeychain(keychain);
+
+        try {
+            const result = await resumeUpload(
+                file,
+                resumableUpload,
+                (progress) => setUploadProgress(progress),
+                (error) => console.error('Resume error:', error),
+                canceller,
+            );
+
+            const uploaded: UploadedFile = {
+                id: result.id,
+                url: result.url,
+                secretKey: keychain.secretKeyB64,
+                ownerToken: result.ownerToken,
+                name: file.name,
+                size: file.size,
+                expiresAt: new Date(Date.now() + resumableUpload.timeLimit * 1000),
+                downloadLimit: resumableUpload.downloadLimit,
+                downloadCount: 0,
+            };
+
+            addUploadedFile(uploaded);
+            setUploadedFile(uploaded);
+            clearFiles();
+            setResumableUpload(null);
+
+            addToast({
+                title: 'Upload resumed and completed!',
+                description: 'Your file is ready to share.',
+                variant: 'success',
+            });
+        } catch (e: unknown) {
+            const message = e instanceof Error ? e.message : String(e);
+            if (message !== 'Upload cancelled') {
+                setUploadError(message);
+                addToast({
+                    title: 'Resume failed',
+                    description: message,
+                    variant: 'destructive',
+                });
+            }
+        } finally {
+            setUploading(false);
+            setUploadProgress(null);
+            setCanceller(null);
+            setKeychain(null);
+        }
+    }, [
+        resumableUpload,
+        files,
+        setUploading,
+        setUploadError,
+        setCanceller,
+        setKeychain,
+        setUploadProgress,
+        addUploadedFile,
+        clearFiles,
+        addToast,
+        setResumableUpload,
+    ]);
+
+    const handleStartFresh = useCallback(() => {
+        if (resumableUpload) {
+            deleteUploadState(resumableUpload.fileId).catch(() => {
+                // Intentionally ignored — best-effort cleanup
+            });
+            setResumableUpload(null);
+        }
+    }, [resumableUpload, setResumableUpload]);
 
     const handleUpload = useCallback(async () => {
         if (files.length === 0) {
@@ -282,6 +385,31 @@ export function HomePage() {
                                                 <UploadSettings />
                                             </div>
                                         )}
+                                    </div>
+                                )}
+
+                                {resumableUpload && !isUploading && (
+                                    <div className="bg-overlay-subtle border border-border-medium rounded-element p-4">
+                                        <p className="text-paragraph-sm font-medium text-content-primary mb-1">
+                                            Resume previous upload?
+                                        </p>
+                                        <p className="text-paragraph-xs text-content-secondary mb-3">
+                                            A previous upload of this file was interrupted.{' '}
+                                            {resumableUpload.completedParts.length} of{' '}
+                                            {resumableUpload.totalParts} parts completed.
+                                        </p>
+                                        <div className="flex gap-2">
+                                            <Button size="sm" onClick={handleResume}>
+                                                Resume
+                                            </Button>
+                                            <Button
+                                                size="sm"
+                                                variant="ghost"
+                                                onClick={handleStartFresh}
+                                            >
+                                                Start fresh
+                                            </Button>
+                                        </div>
                                     </div>
                                 )}
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -40,6 +40,7 @@ export function HomePage() {
         setCanceller,
         setKeychain,
         setZippingProgress,
+        setCheckingSpeed,
         addUploadedFile,
         addToast,
         config,
@@ -193,6 +194,9 @@ export function HomePage() {
                     onZipProgress: (percent) => {
                         setZippingProgress(percent);
                     },
+                    onSpeedTest: (phase) => {
+                        setCheckingSpeed(phase === 'started');
+                    },
                     onError: (error) => {
                         console.error('Upload error:', error);
                     },
@@ -274,6 +278,7 @@ export function HomePage() {
             setUploading(false);
             setUploadProgress(null);
             setZippingProgress(null);
+            setCheckingSpeed(false);
             setCanceller(null);
             setKeychain(null);
         }
@@ -291,6 +296,7 @@ export function HomePage() {
         clearFiles,
         addToast,
         setZippingProgress,
+        setCheckingSpeed,
     ]);
 
     const totalSize = files.reduce((sum, f) => sum + f.file.size, 0);

--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -50,6 +50,7 @@ export interface AppState {
     currentCanceller: Canceller | null;
     currentKeychain: Keychain | null;
     zippingProgress: number | null; // 0-100 percentage while zipping multiple files
+    checkingSpeed: boolean;
 
     setUploading: (uploading: boolean) => void;
     setUploadProgress: (progress: UploadProgress | null) => void;
@@ -57,6 +58,7 @@ export interface AppState {
     setCanceller: (canceller: Canceller | null) => void;
     setKeychain: (keychain: Keychain | null) => void;
     setZippingProgress: (progress: number | null) => void;
+    setCheckingSpeed: (checking: boolean) => void;
 
     // Uploaded files history
     uploadedFiles: UploadedFile[];
@@ -135,6 +137,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     currentCanceller: null,
     currentKeychain: null,
     zippingProgress: null,
+    checkingSpeed: false,
 
     setUploading: (isUploading) => set({ isUploading }),
     setUploadProgress: (uploadProgress) => set({ uploadProgress }),
@@ -142,6 +145,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     setCanceller: (currentCanceller) => set({ currentCanceller }),
     setKeychain: (currentKeychain) => set({ currentKeychain }),
     setZippingProgress: (zippingProgress) => set({ zippingProgress }),
+    setCheckingSpeed: (checkingSpeed) => set({ checkingSpeed }),
 
     // Uploaded files
     uploadedFiles: loadUploadedFiles(),

--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { type Canceller, deleteFile, type UploadProgress } from '@/lib/api';
 import type { Keychain } from '@/lib/crypto';
 import { captureError } from '@/lib/sentry';
+import type { PersistedUpload } from '@/lib/upload-state';
 
 export interface FileItem {
     id: string;
@@ -63,6 +64,10 @@ export interface AppState {
     removeUploadedFile: (id: string) => void;
     updateUploadedFile: (id: string, updates: Partial<UploadedFile>) => void;
     clearUploadedFiles: () => void;
+
+    // Resumable upload
+    resumableUpload: PersistedUpload | null;
+    setResumableUpload: (upload: PersistedUpload | null) => void;
 
     // Config
     config: {
@@ -194,6 +199,10 @@ export const useAppStore = create<AppState>((set, get) => ({
         localStorage.removeItem('uploadedFiles');
         set({ uploadedFiles: [] });
     },
+
+    // Resumable upload
+    resumableUpload: null,
+    setResumableUpload: (resumableUpload) => set({ resumableUpload }),
 
     // Config
     config: null,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "shared"
     ],
     "scripts": {
-        "dev": "bunx dotenvx run -f .env* -- bun run --cwd backend dev & bun run --cwd frontend dev",
+        "dev": "bunx dotenvx run -f .env* -- bun run --cwd backend dev & bunx dotenvx run -f .env* -- bun run --cwd frontend dev",
         "dev:frontend": "bun run --cwd frontend dev",
         "dev:backend": "bunx dotenvx run -f .env* -- bun run --cwd backend dev",
         "build": "bun run --cwd frontend build && bun run --cwd backend build",
@@ -22,7 +22,7 @@
         "format": "bunx biome format --write .",
         "check": "bunx biome check --write .",
         "commit": "cz",
-        "prepare": "lefthook install"
+        "prepare": "lefthook install || true"
     },
     "config": {
         "commitizen": {

--- a/shared/config.ts
+++ b/shared/config.ts
@@ -34,6 +34,15 @@ export const DOWNLOAD_LIMITS = {
     DOWNLOAD_COUNTS: [1, 2, 3, 4, 5, 20, 50, 100],
 } as const;
 
+// Part size tiers based on observed upload speed
+// Slower connections use smaller parts to reduce wasted bandwidth on retries
+export const PART_SIZE_TIERS = [
+    { minSpeed: 50 * BYTES.MB, partSize: 200 * BYTES.MB }, // ≥50 MB/s
+    { minSpeed: 10 * BYTES.MB, partSize: 100 * BYTES.MB }, // 10-50 MB/s
+    { minSpeed: 2 * BYTES.MB, partSize: 50 * BYTES.MB }, // 2-10 MB/s
+    { minSpeed: 0, partSize: 25 * BYTES.MB }, // <2 MB/s
+] as const;
+
 // UI defaults
 export const UI_DEFAULTS = {
     TITLE: 'Slingshot Send',


### PR DESCRIPTION
## Summary

Comprehensive resilient upload system for users on slow/unstable connections. The root cause was a hard 2-minute XHR timeout on 200MB parts — at 10 Mbps a 200MB part takes ~2.7 minutes, so the timeout always fired before completion, exhausting all retries.

### Stall Detection
- Replace hard 2-minute XHR timeout with 60-second progress-based stall detection
- Slow-but-progressing uploads continue indefinitely; truly stalled connections detected in 60s
- `stalledAbort` flag prevents spurious Sentry errors on intentional abort

### Adaptive Part Sizing
- Multipart preflight speed test: 5x100MB concurrent uploads to S3 for up to 10 seconds
- Maps measured speed to part size tiers (200MB/100MB/50MB/25MB)
- Client sends `preferredPartSize` to backend; backend validates within S3 bounds
- Speed test skipped for single-part uploads (<100MB)

### Online/Offline Awareness
- `waitForOnline()` utility pauses retries when browser goes offline
- Stall timer pauses during offline periods (prevents false stall detection)
- 1-second polling + `online`/`offline` event listeners for immediate UI updates

### Connection Quality UI
- Colored status dot (green/yellow/orange/red/gray) next to upload status
- Context-aware status text: "Checking speed...", "Uploading...", "Retrying...", "Connection stalled...", "Waiting for connection..."
- `onRetry` callback threaded through the entire upload chain

### Upload Resumability (single-file only)
- IndexedDB persistence of multipart upload state (`upload-state.ts`)
- On page reload, shows resume prompt replacing the dropzone — user must select the file to resume or start fresh
- `resumeUpload()` reconstructs keychain, resumes from contiguous completed prefix with correct AES-GCM counter offset
- Backend `POST /upload/multipart/:id/resume` generates URLs for remaining parts
- Multi-file (zipped) uploads excluded — streaming zip can't be reconstructed
- Cancel always cleans up IndexedDB state

### Download Improvements
- Extensive console logging for encrypted download debugging
- Download phase UI: "Downloading... X%", "Decrypting...", "Finalizing..."
- Guard `crypto.subtle` access for non-secure contexts (plain HTTP)

### Infrastructure
- Upload concurrency increased from 3 to 5 (3 for >50GB files)
- Graceful `prepare` script when lefthook unavailable (Docker builds)

## Changes

12 files changed, +1343 / -131

| File | Changes |
|------|---------|
| `frontend/src/lib/api.ts` | Stall detection, speed test, offline awareness, connection quality, IndexedDB persistence, resumeUpload, download logging/phases |
| `frontend/src/lib/upload-state.ts` | New IndexedDB persistence module |
| `frontend/src/lib/crypto.ts` | `initialCounter` param on `createEncryptionStream` |
| `frontend/src/components/UploadProgress.tsx` | Connection quality UI, speed test state |
| `frontend/src/pages/Home.tsx` | Resume detection, banner, file re-selection flow |
| `frontend/src/pages/Download.tsx` | Phase UI, crypto.subtle guard |
| `frontend/src/stores/app.ts` | `resumableUpload`, `checkingSpeed` state |
| `backend/src/routes/upload.ts` | `preferredPartSize`, `partSize` storage, resume endpoint, speed test endpoints |
| `backend/src/storage/index.ts` | `partSize` in FileMetadata, `expiresIn` passthrough |
| `shared/config.ts` | `PART_SIZE_TIERS` |
| `package.json` | Graceful prepare script |